### PR TITLE
add secrets.properties and *.keystore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ wrapper/
 .externalNativeBuild
 .cxx
 local.properties
-
+secrets.properties
+*.keystore


### PR DESCRIPTION
They were removed when some merge was reverted. Put it into a separate PR now, so it is more robust.