### PR TITLE
Trigger CI when merging a pull request into main

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,9 @@ on:
       - opened
       - synchronize
       - reopened
-
+  push:
+    branches:
+      - main
 
 jobs:
   wanderwave-ci:


### PR DESCRIPTION
This will trigger the CI when merging a pull request into the main branch. This would allow us disable branches needing to be up to date before merging with some confidence.