### PR TITLE
Modularize to allow for previews

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconScreenViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconScreenViewModelTest.kt
@@ -9,8 +9,7 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class BeaconScreenViewModelTest {
 
-  @get:Rule
-  val mockkRule = MockKRule(this)
+  @get:Rule val mockkRule = MockKRule(this)
 
   @Test
   fun canConstructWithNoErrors() {

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconScreenViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconScreenViewModelTest.kt
@@ -1,0 +1,19 @@
+package ch.epfl.cs311.wanderwave.viewmodel
+
+import io.mockk.junit4.MockKRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BeaconScreenViewModelTest {
+
+  @get:Rule
+  val mockkRule = MockKRule(this)
+
+  @Test
+  fun canConstructWithNoErrors() {
+    BeaconViewModel()
+  }
+}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -37,6 +37,15 @@ private fun BeaconScreen() {
       }
 }
 
-@Composable fun BeaconInformation() {}
+@Composable
+fun BeaconInformation() {
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Text("Beacon", style = MaterialTheme.typography.displayMedium)
+    Text("Beacon Information")
+  }
+}
 
-@Composable fun SongList() {}
+@Composable
+fun SongList() {
+  Column() { Text("Song List") }
+}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -1,11 +1,24 @@
 package ch.epfl.cs311.wanderwave.ui.screens
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.viewmodel.BeaconViewModel
 
 @Composable
 fun BeaconScreen(navigationActions: NavigationActions, viewModel: BeaconViewModel = hiltViewModel()) {
+  BeaconScreen()
+}
 
+@Composable
+@Preview
+private fun BeaconScreen() {
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(text = "Beacon")
+  }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -2,12 +2,15 @@ package ch.epfl.cs311.wanderwave.ui.screens
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
+import ch.epfl.cs311.wanderwave.ui.theme.WanderwaveTheme
 import ch.epfl.cs311.wanderwave.viewmodel.BeaconViewModel
 
 @Composable
@@ -19,7 +22,21 @@ fun BeaconScreen(
 }
 
 @Composable
-@Preview
-private fun BeaconScreen() {
-  Column(modifier = Modifier.fillMaxSize()) { Text(text = "Beacon") }
+@Preview(showBackground = true)
+private fun BeaconScreenPreview() {
+  WanderwaveTheme { BeaconScreen() }
 }
+
+@Composable
+private fun BeaconScreen() {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        BeaconInformation()
+        SongList()
+      }
+}
+
+@Composable fun BeaconInformation() {}
+
+@Composable fun SongList() {}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -3,6 +3,8 @@ package ch.epfl.cs311.wanderwave.ui.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -11,14 +11,15 @@ import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.viewmodel.BeaconViewModel
 
 @Composable
-fun BeaconScreen(navigationActions: NavigationActions, viewModel: BeaconViewModel = hiltViewModel()) {
+fun BeaconScreen(
+    navigationActions: NavigationActions,
+    viewModel: BeaconViewModel = hiltViewModel()
+) {
   BeaconScreen()
 }
 
 @Composable
 @Preview
 private fun BeaconScreen() {
-  Column(modifier = Modifier.fillMaxSize()) {
-    Text(text = "Beacon")
-  }
+  Column(modifier = Modifier.fillMaxSize()) { Text(text = "Beacon") }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconViewModel.kt
@@ -3,6 +3,4 @@ package ch.epfl.cs311.wanderwave.viewmodel
 import androidx.lifecycle.ViewModel
 import javax.inject.Inject
 
-class BeaconViewModel @Inject constructor() : ViewModel() {
-
-}
+class BeaconViewModel @Inject constructor() : ViewModel() {}


### PR DESCRIPTION
I extracted a BeaconScreen() with no arguments (at the moment, will be filled with information and callbacks that the screen needs), so we can properly test and preview it without duplication.