### PR TITLE
[Bugfix] Lower accompanist version to 0.34.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-accompanistPermissions = "0.35.0-alpha"
+accompanistPermissions = "0.34.0"
 coilCompose = "2.6.0"
 agp = "8.3.1"
 hiltNavigationCompose = "1.2.0"


### PR DESCRIPTION
On my device, attempting to display the TrackList screen causes a crash, including for tests. This issue is also described here: https://github.com/google/accompanist/issues/1752
The described solution is lowering the version of accompanist to 0.34.0, which is also working in my case.