### PR TITLE
remove the "sample beacon" to show a loading animation

### DIFF
--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconViewModel.kt
@@ -3,8 +3,6 @@ package ch.epfl.cs311.wanderwave.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.epfl.cs311.wanderwave.model.data.Beacon
-import ch.epfl.cs311.wanderwave.model.data.Location
-import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.repository.BeaconRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/BeaconViewModel.kt
@@ -21,13 +21,7 @@ class BeaconViewModel @Inject constructor(private val beaconRepository: BeaconRe
   val uiState: StateFlow<UIState> = _uiState
 
   init {
-    val sampleBeacon =
-        Beacon(
-            id = "Sample ID",
-            location = Location(0.0, 0.0, "Sample Location"),
-            tracks = listOf(Track("Sample Track ID", "Sample Track Title", "Sample Artist Name")))
-
-    _uiState.value = UIState(beacon = sampleBeacon, isLoading = false)
+    _uiState.value = UIState(beacon = null, isLoading = true)
   }
 
   fun getBeaconById(id: String) {


### PR DESCRIPTION
The loading animation was gone because the viewmodel was initialized with a dummy beacon. I removed it in favor of `null` and setting `isLoading` to `true`, so now the animation is back.