### PR TITLE
Feature/profile integration/profile private public mode

### DIFF
--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -70,6 +72,7 @@ fun BeaconScreen(
     navigationActions: NavigationActions,
     viewModel: BeaconViewModel = hiltViewModel()
 ) {
+
   LaunchedEffect(beaconId) {
     if (beaconId != null) {
       viewModel.getBeaconById(beaconId)
@@ -174,6 +177,7 @@ internal fun TrackItem(
   val scrollState = rememberScrollState()
   val scope = rememberCoroutineScope()
   val slowScrollAnimation: AnimationSpec<Float> = TweenSpec(durationMillis = 5000, easing = { it })
+  val snackbarHostState = remember { SnackbarHostState() }
 
   LaunchedEffect(key1 = true) {
     while (true) {
@@ -231,9 +235,10 @@ internal fun TrackItem(
                           } else {
                             // if the profile is private , output a message that say the profile is
                             // private, you cannot access to profile informations
-                            Log.d(
-                                "Profile Access",
-                                "This profile is private, You cannot access to profile informations")
+                            scope.launch {
+                              snackbarHostState.showSnackbar(
+                                  "This profile is private, you cannot access profile information.")
+                            }
                           }
                         }),
             profile = profileAndTrack.profile,
@@ -241,4 +246,5 @@ internal fun TrackItem(
       }
     }
   }
+  SnackbarHost(hostState = snackbarHostState)
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -230,7 +230,7 @@ internal fun TrackItem(
                             navigationActions.navigateToProfile(profileAndTrack.profile.firebaseUid)
                           } else {
                             // if the profile is private , output a message that say the profile is
-                            // private
+                            // private, you cannot access to profile informations
                             Log.d(
                                 "Profile Access",
                                 "This profile is private, You cannot access to profile informations")

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -223,8 +223,18 @@ internal fun TrackItem(
             modifier =
                 Modifier.size(width = 150.dp, height = 100.dp)
                     .clickable(
+                        enabled = profileAndTrack.profile.isPublic,
                         onClick = {
-                          navigationActions.navigateToProfile(profileAndTrack.profile.firebaseUid)
+                          if (profileAndTrack.profile.isPublic) {
+                            // if the profile is public, navigate to the profile view screen
+                            navigationActions.navigateToProfile(profileAndTrack.profile.firebaseUid)
+                          } else {
+                            // if the profile is private , output a message that say the profile is
+                            // private
+                            Log.d(
+                                "Profile Access",
+                                "This profile is private, You cannot access to profile informations")
+                          }
                         }),
             profile = profileAndTrack.profile,
         )


### PR DESCRIPTION
When you select a beacon on the map and attempt to view the associated profile, access is granted only if the profile is set to public. If the profile is private, a message will be displayed, informing you that the profile is private and access to the profile information is restricted.