### PR TITLE
Can now navigate to the select song screen from the tracklist screen

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
@@ -61,7 +61,9 @@ class TrackListScreenTest : TestCase() {
 
     viewModel = TrackListViewModel(mockSpotifyController, trackRepository)
 
-    composeTestRule.setContent { TrackListScreen(mockNavigationActions,mockShowMessage, viewModel) }
+    composeTestRule.setContent {
+      TrackListScreen(mockNavigationActions, mockShowMessage, viewModel)
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.repository.TrackRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
+import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.ui.screens.TrackListScreen
 import ch.epfl.cs311.wanderwave.viewmodel.TrackListViewModel
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -33,6 +34,7 @@ class TrackListScreenTest : TestCase() {
 
   @RelaxedMockK lateinit var mockSpotifyController: SpotifyController
   @RelaxedMockK lateinit var trackRepository: TrackRepository
+  @RelaxedMockK private lateinit var mockNavigationActions: NavigationActions
 
   @RelaxedMockK lateinit var viewModel: TrackListViewModel
 
@@ -59,7 +61,7 @@ class TrackListScreenTest : TestCase() {
 
     viewModel = TrackListViewModel(mockSpotifyController, trackRepository)
 
-    composeTestRule.setContent { TrackListScreen(mockShowMessage, viewModel) }
+    composeTestRule.setContent { TrackListScreen(mockNavigationActions,mockShowMessage, viewModel) }
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
@@ -1,13 +1,17 @@
 package ch.epfl.cs311.wanderwave.ui
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.NavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.cs311.wanderwave.model.data.Track
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.model.repository.TrackRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
+import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.screens.TrackListScreen
 import ch.epfl.cs311.wanderwave.viewmodel.TrackListViewModel
+import com.google.common.base.Verify.verify
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onComposeScreen
 import io.mockk.Called
@@ -15,6 +19,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.verify
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -39,8 +44,13 @@ class TrackListScreenTest : TestCase() {
   @RelaxedMockK lateinit var viewModel: TrackListViewModel
 
   @RelaxedMockK lateinit var mockShowMessage: (String) -> Unit
+  @RelaxedMockK private lateinit var mockNavController: NavHostController
 
-  @Before fun setup() {}
+  @Before fun setup() {
+
+    every { mockNavController.navigate(any<String>()) } returns Unit
+    mockNavigationActions = NavigationActions(mockNavController)
+  }
 
   @After
   fun tearDown() {
@@ -79,5 +89,10 @@ class TrackListScreenTest : TestCase() {
       advanceUntilIdle()
       coVerify { mockShowMessage wasNot Called }
     }
+  }
+  @Test
+  fun canNavigateToSElectSongScreenFromTrackListScreen() = run {
+    mockNavigationActions.navigateToSelectSongScreen(viewModelType.TRACKLIST)
+    verify { mockNavController.navigate("${Route.SELECT_SONG.routeString}/tracklist") }
   }
 }

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
@@ -46,7 +46,8 @@ class TrackListScreenTest : TestCase() {
   @RelaxedMockK lateinit var mockShowMessage: (String) -> Unit
   @RelaxedMockK private lateinit var mockNavController: NavHostController
 
-  @Before fun setup() {
+  @Before
+  fun setup() {
 
     every { mockNavController.navigate(any<String>()) } returns Unit
     mockNavigationActions = NavigationActions(mockNavController)
@@ -90,6 +91,7 @@ class TrackListScreenTest : TestCase() {
       coVerify { mockShowMessage wasNot Called }
     }
   }
+
   @Test
   fun canNavigateToSElectSongScreenFromTrackListScreen() = run {
     mockNavigationActions.navigateToSelectSongScreen(viewModelType.TRACKLIST)

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
@@ -88,41 +88,6 @@ class ProfileViewModelTest {
     assertTrue("Song list should contain the newly added track", songsInList.contains(newTrack))
   }
 
-  @Test
-  fun retrieveTrackTest() = runBlockingTest {
-    val track = ListItem("bbbb", "bbbb", null, "bbbb", "bbbb", false, true)
-    val track2 = ListItem("aaaa", "aaaaa", null, "aaaaa", "aaaaa", false, true)
-
-    // Mocking responses for your spotifyController
-    every { spotifyController.getAllElementFromSpotify() } returns flowOf(listOf(track))
-    every { spotifyController.getAllChildren(track) } returns flowOf(listOf(track2))
-
-    viewModel.createSpecificSongList(ListType.TOP_SONGS)
-    // Start observing the Flow before triggering actions that modify it
-    val job = launch {
-      viewModel.songLists.collect { songLists ->
-        if (songLists.isNotEmpty()) {
-          cancel() // Stop collecting once we have our expected result
-        }
-      }
-    }
-
-    // Trigger the operations that will cause the song lists to be populated
-    viewModel.retrieveTracks()
-    // Wait for the job to complete which includes Flow collection
-    job.join()
-
-    // Since Flow collection is asynchronous, ensure the Flow has time to collect
-    advanceUntilIdle()
-
-    // Optionally check additional conditions after ensuring Flow had time to collect
-
-    assertFalse(
-        "Song list should not be empty after adding a track", viewModel.songLists.value.isEmpty())
-    assertEquals(
-        Track(track2.id, track2.title, track2.subtitle),
-        viewModel.songLists.value.first().tracks.get(0))
-  }
 
   @Test
   fun testGetAllChildrenFlow() = runBlockingTest {

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.remote.ProfileConnection
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import com.spotify.protocol.types.ListItem
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -73,17 +74,17 @@ class ProfileViewModelTest {
     assertTrue(viewModel.songLists.value.isEmpty())
 
     // Call createSpecificSongList to initialize a list
-    viewModel.createSpecificSongList("TOP_SONGS")
+    viewModel.createSpecificSongList(ListType.TOP_SONGS)
 
     // Add track to "TOP SONGS"
-    viewModel.addTrackToList("TOP SONGS", newTrack)
+    viewModel.addTrackToList(ListType.TOP_SONGS, newTrack)
 
     // Get the updated song list
     val songLists = viewModel.songLists.value
     assertFalse("Song list should not be empty after adding a track", songLists.isEmpty())
 
     // Check if the track was added correctly
-    val songsInList = songLists.find { it.name == "TOP SONGS" }?.tracks ?: emptyList()
+    val songsInList = songLists.find { it.name == ListType.TOP_SONGS}?.tracks ?: emptyList()
     assertTrue("Song list should contain the newly added track", songsInList.contains(newTrack))
   }
 
@@ -96,7 +97,7 @@ class ProfileViewModelTest {
     every { spotifyController.getAllElementFromSpotify() } returns flowOf(listOf(track))
     every { spotifyController.getAllChildren(track) } returns flowOf(listOf(track2))
 
-    viewModel.createSpecificSongList("TOP_SONGS")
+    viewModel.createSpecificSongList(ListType.TOP_SONGS)
     // Start observing the Flow before triggering actions that modify it
     val job = launch {
       viewModel.songLists.collect { songLists ->

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
@@ -1,10 +1,10 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.remote.ProfileConnection
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
-import ch.epfl.cs311.wanderwave.model.data.ListType
 import com.spotify.protocol.types.ListItem
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -13,13 +13,11 @@ import io.mockk.junit4.MockKRule
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.timeout
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -84,10 +82,9 @@ class ProfileViewModelTest {
     assertFalse("Song list should not be empty after adding a track", songLists.isEmpty())
 
     // Check if the track was added correctly
-    val songsInList = songLists.find { it.name == ListType.TOP_SONGS}?.tracks ?: emptyList()
+    val songsInList = songLists.find { it.name == ListType.TOP_SONGS }?.tracks ?: emptyList()
     assertTrue("Song list should contain the newly added track", songsInList.contains(newTrack))
   }
-
 
   @Test
   fun testGetAllChildrenFlow() = runBlockingTest {

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModelTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
@@ -27,7 +28,6 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.time.Duration.Companion.seconds
 
 class TrackListViewModelTest {
 
@@ -367,11 +367,12 @@ class TrackListViewModelTest {
     viewModel.toggleLoop()
     assertEquals(LoopMode.NONE, viewModel.uiState.value.loopMode)
   }
+
   @Test
   fun testGetAllChildrenFlow() = runBlockingTest {
     val expectedListItem = ListItem("id", "title", null, "subtitle", "", false, true)
     every { mockSpotifyController.getAllChildren(expectedListItem) } returns
-            flowOf(listOf(expectedListItem))
+        flowOf(listOf(expectedListItem))
 
     val result = mockSpotifyController.getAllChildren(expectedListItem)
     assertEquals(expectedListItem, result.first().get(0)) // Check if the first item is as expected
@@ -380,9 +381,11 @@ class TrackListViewModelTest {
   @Test
   fun testRetrieveSubsectionAndChildrenFlow() = runBlockingTest {
     val expectedListItem = ListItem("id", "title", null, "subtitle", "", false, true)
-    every { mockSpotifyController.getAllElementFromSpotify() } returns flowOf(listOf(expectedListItem))
+    every { mockSpotifyController.getAllElementFromSpotify() } returns
+        flowOf(listOf(expectedListItem))
     every {
-      mockSpotifyController.getAllChildren(ListItem("id", "title", null, "subtitle", "", false, true))
+      mockSpotifyController.getAllChildren(
+          ListItem("id", "title", null, "subtitle", "", false, true))
     } returns flowOf(listOf(expectedListItem))
     viewModel.retrieveAndAddSubsection()
     viewModel.retrieveChild(expectedListItem)

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/ListType.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/ListType.kt
@@ -1,7 +1,7 @@
 package ch.epfl.cs311.wanderwave.model.data
 
 enum class ListType {
-    TOP_SONGS,
-    CHOSEN_SONGS,
-    OTHERS
+  TOP_SONGS,
+  CHOSEN_SONGS,
+  OTHERS
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/ListType.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/ListType.kt
@@ -1,0 +1,7 @@
+package ch.epfl.cs311.wanderwave.model.data
+
+enum class ListType {
+    TOP_SONGS,
+    CHOSEN_SONGS,
+    OTHERS
+}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
@@ -1,4 +1,4 @@
 package ch.epfl.cs311.wanderwave.model.data
 
-enum class viewModelType {PROFILE, TRACKLIST, SONGLIST, SPOTIFYSONGACTIONS, UISTATE, LISTTYPE
+enum class viewModelType {PROFILE, TRACKLIST, SONGLIST, SPOTIFYSONGACTIONS, UISTATE, LISTTYPE, NULL
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
@@ -1,4 +1,4 @@
 package ch.epfl.cs311.wanderwave.model.data
 
-enum class viewModelType {PROFILE, TRACKLIST, SONGLIST, SPOTIFYSONGACTIONS, UISTATE, LISTTYPE, NULL
+enum class viewModelType {PROFILE, TRACKLIST, SONGLIST, UISTATE, LISTTYPE, NULL
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
@@ -1,4 +1,10 @@
 package ch.epfl.cs311.wanderwave.model.data
 
-enum class viewModelType {PROFILE, TRACKLIST, SONGLIST, UISTATE, LISTTYPE, NULL
+enum class viewModelType {
+  PROFILE,
+  TRACKLIST,
+  SONGLIST,
+  UISTATE,
+  LISTTYPE,
+  NULL
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/data/viewModelType.kt
@@ -1,0 +1,4 @@
+package ch.epfl.cs311.wanderwave.model.data
+
+enum class viewModelType {PROFILE, TRACKLIST, SONGLIST, SPOTIFYSONGACTIONS, UISTATE, LISTTYPE
+}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
@@ -16,11 +16,14 @@ import com.spotify.sdk.android.auth.AuthorizationResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 class SpotifyController(private val context: Context) {
@@ -296,5 +299,47 @@ class SpotifyController(private val context: Context) {
     SUCCESS,
     NOT_LOGGED_IN,
     FAILED
+  }
+}
+/**
+ * Get all the element of the main screen and add them to the top list
+ *
+ * @author Menzo Bouaissi
+ * @since 2.0
+ * @last update 3.0
+ */
+fun retrieveAndAddSubsectionFromSpotify(
+    spotifySubsectionList: MutableStateFlow<List<ListItem>>,
+    spotifyController: SpotifyController
+) {
+  GlobalScope.launch {
+    val track = spotifyController.getAllElementFromSpotify().firstOrNull()
+    if (track != null) {
+      for (i in track) {
+        spotifySubsectionList.value += i
+      }
+    }
+  }
+}
+
+/**
+ * Get all the element of the main screen and add them to the top list
+ *
+ * @author Menzo Bouaissi
+ * @since 2.0
+ * @last update 3.0
+ */
+fun retrieveChildFromSpotify(
+    item: ListItem,
+    childrenPlaylistTrackList: MutableStateFlow<List<ListItem>>,
+    spotifyController: SpotifyController
+) {
+  GlobalScope.launch {
+    val children = spotifyController.getAllChildren(item).firstOrNull()
+    if (children != null) {
+      for (child in children) {
+        childrenPlaylistTrackList.value += child
+      }
+    }
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
@@ -16,7 +16,6 @@ import com.spotify.sdk.android.auth.AuthorizationResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
@@ -310,9 +309,10 @@ class SpotifyController(private val context: Context) {
  */
 fun retrieveAndAddSubsectionFromSpotify(
     spotifySubsectionList: MutableStateFlow<List<ListItem>>,
-    spotifyController: SpotifyController
+    spotifyController: SpotifyController,
+    scope: CoroutineScope
 ) {
-  GlobalScope.launch {
+  scope.launch {
     val track = spotifyController.getAllElementFromSpotify().firstOrNull()
     if (track != null) {
       for (i in track) {
@@ -332,9 +332,10 @@ fun retrieveAndAddSubsectionFromSpotify(
 fun retrieveChildFromSpotify(
     item: ListItem,
     childrenPlaylistTrackList: MutableStateFlow<List<ListItem>>,
-    spotifyController: SpotifyController
+    spotifyController: SpotifyController,
+    scope: CoroutineScope
 ) {
-  GlobalScope.launch {
+  scope.launch {
     val children = spotifyController.getAllChildren(item).firstOrNull()
     if (children != null) {
       for (child in children) {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
@@ -6,6 +6,7 @@ import ch.epfl.cs311.wanderwave.R
 import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.Locale
 
 enum class Route(val routeString: String, val showBottomBar: Boolean) {
   LOGIN("login", false),
@@ -80,8 +81,9 @@ class NavigationActions(navController: NavHostController) {
     navigationController.navigate("${Route.VIEW_PROFILE.routeString}/$profileId")
     _currentRouteFlow.value = Route.PROFILE
   }
-  fun navigateToSelectSongScreen(viewModelType: String) {
-    navigationController.navigate("${Route.SELECT_SONG.routeString}/$viewModelType")
+  fun navigateToSelectSongScreen(viewModelType: viewModelType) {
+    val type = viewModelType.name.lowercase(Locale.getDefault()) // Converts enum to a lowercase string
+    navigationController.navigate("${Route.SELECT_SONG.routeString}/$type")
   }
   fun goBack() {
     navigationController.popBackStack()

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
@@ -3,6 +3,7 @@ package ch.epfl.cs311.wanderwave.navigation
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import ch.epfl.cs311.wanderwave.R
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -79,7 +80,9 @@ class NavigationActions(navController: NavHostController) {
     navigationController.navigate("${Route.VIEW_PROFILE.routeString}/$profileId")
     _currentRouteFlow.value = Route.PROFILE
   }
-
+  fun navigateToSelectSongScreen(viewModelType: String) {
+    navigationController.navigate("${Route.SELECT_SONG.routeString}/$viewModelType")
+  }
   fun goBack() {
     navigationController.popBackStack()
   }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
@@ -4,9 +4,9 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import ch.epfl.cs311.wanderwave.R
 import ch.epfl.cs311.wanderwave.model.data.viewModelType
+import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import java.util.Locale
 
 enum class Route(val routeString: String, val showBottomBar: Boolean) {
   LOGIN("login", false),
@@ -81,10 +81,13 @@ class NavigationActions(navController: NavHostController) {
     navigationController.navigate("${Route.VIEW_PROFILE.routeString}/$profileId")
     _currentRouteFlow.value = Route.PROFILE
   }
+
   fun navigateToSelectSongScreen(viewModelType: viewModelType) {
-    val type = viewModelType.name.lowercase(Locale.getDefault()) // Converts enum to a lowercase string
+    val type =
+        viewModelType.name.lowercase(Locale.getDefault()) // Converts enum to a lowercase string
     navigationController.navigate("${Route.SELECT_SONG.routeString}/$type")
   }
+
   fun goBack() {
     navigationController.popBackStack()
   }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/App.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/App.kt
@@ -102,7 +102,7 @@ fun AppScaffold(navController: NavHostController) {
                   val viewModelType = backStackEntry.arguments?.getString("viewModelType")
                   val viewModel = when (viewModelType) {
                       "profile" -> profileViewModel
-                      "trackList" -> trackListViewModel
+                      "tracklist" -> trackListViewModel
                       else -> throw IllegalStateException("Invalid ViewModel type for SelectSongScreen")
                   }
 

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/App.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/App.kt
@@ -59,10 +59,10 @@ fun AppScaffold(navController: NavHostController) {
   var showBottomBar by remember { mutableStateOf(false) }
   val currentRouteState by navActions.currentRouteFlow.collectAsStateWithLifecycle()
   val snackbarHostState = remember { SnackbarHostState() }
-    val profileViewModel: ProfileViewModel = hiltViewModel()
-    val trackListViewModel = hiltViewModel<TrackListViewModel>()
+  val profileViewModel: ProfileViewModel = hiltViewModel()
+  val trackListViewModel = hiltViewModel<TrackListViewModel>()
 
-    val scope = rememberCoroutineScope()
+  val scope = rememberCoroutineScope()
   val showSnackbar = { message: String ->
     scope.launch { snackbarHostState.showSnackbar(message) }
     Unit
@@ -88,26 +88,32 @@ fun AppScaffold(navController: NavHostController) {
                 composable(Route.SPOTIFY_CONNECT.routeString) { SpotifyConnectScreen(navActions) }
                 composable(Route.ABOUT.routeString) { AboutScreen(navActions) }
                 composable(Route.TRACK_LIST.routeString) {
-                  TrackListScreen(navActions,showSnackbar, trackListViewModel)
+                  TrackListScreen(navActions, showSnackbar, trackListViewModel)
                 }
                 composable(Route.MAP.routeString) { MapScreen(navActions) }
-                composable(Route.PROFILE.routeString) { ProfileScreen(navActions, profileViewModel) }
+                composable(Route.PROFILE.routeString) {
+                  ProfileScreen(navActions, profileViewModel)
+                }
                 composable(Route.EDIT_PROFILE.routeString) {
                   EditProfileScreen(navActions, profileViewModel)
                 }
-              composable(
-                  route = "${Route.SELECT_SONG.routeString}/{viewModelType}",
-                  arguments = listOf(navArgument("viewModelType") { type = NavType.StringType })
-              ) { backStackEntry ->
-                  val viewModelType = backStackEntry.arguments?.getString("viewModelType")
-                  val viewModel = when (viewModelType) {
-                      "profile" -> profileViewModel
-                      "tracklist" -> trackListViewModel
-                      else -> throw IllegalStateException("Invalid ViewModel type for SelectSongScreen")
-                  }
+                composable(
+                    route = "${Route.SELECT_SONG.routeString}/{viewModelType}",
+                    arguments =
+                        listOf(navArgument("viewModelType") { type = NavType.StringType })) {
+                        backStackEntry ->
+                      val viewModelType = backStackEntry.arguments?.getString("viewModelType")
+                      val viewModel =
+                          when (viewModelType) {
+                            "profile" -> profileViewModel
+                            "tracklist" -> trackListViewModel
+                            else ->
+                                throw IllegalStateException(
+                                    "Invalid ViewModel type for SelectSongScreen")
+                          }
 
-                  SelectSongScreen(navActions, viewModel)
-              }
+                      SelectSongScreen(navActions, viewModel)
+                    }
                 composable("${Route.VIEW_PROFILE.routeString}/{profileId}") {
                   ProfileViewOnlyScreen(it.arguments?.getString("profileId") ?: "", navActions)
                 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
@@ -15,18 +15,17 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import ch.epfl.cs311.wanderwave.model.data.Track
-import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
 import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
+import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
 import ch.epfl.cs311.wanderwave.viewmodel.SongList
 import com.spotify.protocol.types.ListItem
 
@@ -103,16 +102,16 @@ fun AddTrackDialog(
  *
  * @param songLists List of song lists including "TOP SONGS" and "CHOSEN SONGS".
  * @param isTopSongsListVisible Boolean state to toggle between showing "TOP SONGS" or "CHOSEN
- *  SONGS".
- *  @param onAddTrack Callback function to be invoked when a track is added.
- *  @param canAddSong Boolean state to enable or disable adding a song.
- *  @param viewModelName The name of the view model.
- *  @param navigationActions The navigation actions.
+ *   SONGS".
+ *     @param onAddTrack Callback function to be invoked when a track is added.
+ *     @param canAddSong Boolean state to enable or disable adding a song.
+ *     @param viewModelName The name of the view model.
+ *     @param navigationActions The navigation actions.
  *
- *  @author Menzo Bouaissi
- *  @author Ayman Bakiri
- *  @since 1.0
- *  @last update 2.0
+ *     @author Menzo Bouaissi
+ *     @author Ayman Bakiri
+ *     @since 1.0
+ *     @last update 2.0
  */
 @Composable
 fun SongsListDisplay(
@@ -133,13 +132,10 @@ fun SongsListDisplay(
             onSelectTrack = { /* TODO */},
             onAddTrack = onAddTrack,
             canAddSong = canAddSong,
-            navActions = navigationActions,// TODO: Pass the correct navActions),
-            viewModelName = viewModelName
-        )
+            navActions = navigationActions, // TODO: Pass the correct navActions),
+            viewModelName = viewModelName)
       }
 }
-
-
 
 /**
  * Composable that displays a Track. Each track is represented by the TrackItem composable, which is

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
@@ -103,10 +103,16 @@ fun AddTrackDialog(
  *
  * @param songLists List of song lists including "TOP SONGS" and "CHOSEN SONGS".
  * @param isTopSongsListVisible Boolean state to toggle between showing "TOP SONGS" or "CHOSEN
- *   SONGS".
- *     * @author Ayman Bakiri
- *     * @since 1.0
- *     * @last update 1.0
+ *  SONGS".
+ *  @param onAddTrack Callback function to be invoked when a track is added.
+ *  @param canAddSong Boolean state to enable or disable adding a song.
+ *  @param viewModelName The name of the view model.
+ *  @param navigationActions The navigation actions.
+ *
+ *  @author Menzo Bouaissi
+ *  @author Ayman Bakiri
+ *  @since 1.0
+ *  @last update 2.0
  */
 @Composable
 fun SongsListDisplay(

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
@@ -24,51 +24,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
+import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.viewmodel.SongList
 import com.spotify.protocol.types.ListItem
-
-/**
- * Composable that displays a list of tracks. Each track is represented by the TrackItem composable.
- *
- * @param tracks List of tracks to display.
- * @author Ayman Bakiri
- * @author Menzo Bouaissi (add the scrollable list)
- * @since 1.0
- * @last update 2.0
- */
-@Composable
-fun TracksList(tracks: List<Track>) {
-  tracks.forEach { track -> key(track.id) { TrackItem(track = track) } }
-}
-
-/**
- * Composable that displays information for a single track, including its ID, title, and artist.
- *
- * @param track The track data to display.
- * @author Ayman Bakiri
- * @author Menzo Bouaissi
- * @since 1.0
- * @last update 2.0
- */
-@Composable
-fun TrackItem(track: Track, onClick: () -> Unit = {}) {
-  Card(
-      colors =
-          CardDefaults.cardColors(
-              containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-              contentColor = MaterialTheme.colorScheme.onSurface,
-              disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
-              disabledContentColor = MaterialTheme.colorScheme.error // Example color
-              ),
-      modifier = Modifier.height(80.dp).fillMaxWidth().padding(4.dp).clickable(onClick = onClick)) {
-        Row {
-          Column(modifier = Modifier.padding(8.dp)) {
-            Text(text = track.title, style = MaterialTheme.typography.titleMedium)
-            Text(text = track.artist, style = MaterialTheme.typography.bodyMedium)
-          }
-        }
-      }
-}
 
 /**
  * Dialog composable that allows the user to add a new track by entering the track ID, title, and
@@ -150,23 +109,30 @@ fun AddTrackDialog(
  */
 @Composable
 fun SongsListDisplay(
+    navigationActions: NavigationActions,
     songLists: List<SongList>,
     isTopSongsListVisible: Boolean,
     onAddTrack: (Track) -> Unit,
-    canAddSong: Boolean = true
+    canAddSong: Boolean = true,
+    viewModelName: String = ""
 ) {
-  val name = if (isTopSongsListVisible) "TOP SONGS" else "CHOSEN SONGS"
+  val name = if (isTopSongsListVisible) ListType.TOP_SONGS else ListType.CHOSEN_SONGS
   songLists
       .firstOrNull { it.name == name }
       ?.let { songList ->
         TrackList(
             tracks = songList.tracks,
-            title = name,
+            title = name.name,
             onSelectTrack = { /* TODO */},
             onAddTrack = onAddTrack,
-            canAddSong = canAddSong)
+            canAddSong = canAddSong,
+            navActions = navigationActions,// TODO: Pass the correct navActions),
+            viewModelName = viewModelName
+        )
       }
 }
+
+
 
 /**
  * Composable that displays a Track. Each track is represented by the TrackItem composable, which is

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
 import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.viewmodel.SongList
 import com.spotify.protocol.types.ListItem
@@ -114,7 +115,7 @@ fun SongsListDisplay(
     isTopSongsListVisible: Boolean,
     onAddTrack: (Track) -> Unit,
     canAddSong: Boolean = true,
-    viewModelName: String = ""
+    viewModelName: viewModelType = viewModelType.NULL
 ) {
   val name = if (isTopSongsListVisible) ListType.TOP_SONGS else ListType.CHOSEN_SONGS
   songLists

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/TrackActions.kt
@@ -132,7 +132,7 @@ fun SongsListDisplay(
             onSelectTrack = { /* TODO */},
             onAddTrack = onAddTrack,
             canAddSong = canAddSong,
-            navActions = navigationActions, // TODO: Pass the correct navActions),
+            navActions = navigationActions,
             viewModelName = viewModelName)
       }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/tracklist/TrackList.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/tracklist/TrackList.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import ch.epfl.cs311.wanderwave.R
 import ch.epfl.cs311.wanderwave.model.data.Track
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.profile.AddTrackDialog
@@ -38,7 +39,7 @@ fun TrackList(
     onSelectTrack: (Track) -> Unit = {},
     canAddSong: Boolean = true,
     navActions: NavigationActions,
-    viewModelName : String
+    viewModelName : viewModelType
 ) {
 
   Column {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/tracklist/TrackList.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/tracklist/TrackList.kt
@@ -25,7 +25,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import ch.epfl.cs311.wanderwave.R
 import ch.epfl.cs311.wanderwave.model.data.Track
+import ch.epfl.cs311.wanderwave.navigation.NavigationActions
+import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.profile.AddTrackDialog
+import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 
 @Composable
 fun TrackList(
@@ -33,7 +36,9 @@ fun TrackList(
     title: String? = null,
     onAddTrack: (Track) -> Unit,
     onSelectTrack: (Track) -> Unit = {},
-    canAddSong: Boolean = true
+    canAddSong: Boolean = true,
+    navActions: NavigationActions,
+    viewModelName : String
 ) {
 
   Column {
@@ -51,7 +56,7 @@ fun TrackList(
                 modifier = Modifier.testTag("trackListTitle"))
           }
           if (canAddSong) {
-            IconButton(onClick = { showDialog = true }) { // Toggle dialog visibility
+            IconButton(onClick = { navActions.navigateToSelectSongScreen(viewModelName) }) { // Toggle dialog visibility
               Icon(
                   imageVector = Icons.Filled.Add,
                   contentDescription = stringResource(R.string.beaconTitle))

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/tracklist/TrackList.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/tracklist/TrackList.kt
@@ -27,9 +27,7 @@ import ch.epfl.cs311.wanderwave.R
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
-import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.profile.AddTrackDialog
-import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 
 @Composable
 fun TrackList(
@@ -39,7 +37,7 @@ fun TrackList(
     onSelectTrack: (Track) -> Unit = {},
     canAddSong: Boolean = true,
     navActions: NavigationActions,
-    viewModelName : viewModelType
+    viewModelName: viewModelType
 ) {
 
   Column {
@@ -57,11 +55,14 @@ fun TrackList(
                 modifier = Modifier.testTag("trackListTitle"))
           }
           if (canAddSong) {
-            IconButton(onClick = { navActions.navigateToSelectSongScreen(viewModelName) }) { // Toggle dialog visibility
-              Icon(
-                  imageVector = Icons.Filled.Add,
-                  contentDescription = stringResource(R.string.beaconTitle))
-            }
+            IconButton(
+                onClick = {
+                  navActions.navigateToSelectSongScreen(viewModelName)
+                }) { // Toggle dialog visibility
+                  Icon(
+                      imageVector = Icons.Filled.Add,
+                      contentDescription = stringResource(R.string.beaconTitle))
+                }
           }
         }
     LazyColumn {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
@@ -34,15 +34,15 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Profile
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.profile.ClickableIcon
 import ch.epfl.cs311.wanderwave.ui.components.profile.SelectImage
 import ch.epfl.cs311.wanderwave.ui.components.profile.SongsListDisplay
 import ch.epfl.cs311.wanderwave.ui.components.profile.VisitCard
-import ch.epfl.cs311.wanderwave.model.data.ListType
-import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 
 const val SCALE_X = 0.5f
@@ -94,11 +94,11 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
 
         // Call the SongsListDisplay function
         // Buttons for adding tracks to top songs lists
-//        Button(
-//            onClick = { navActions.navigateToSelectSongScreen(viewModelType.PROFILE) },
-//            modifier = Modifier.testTag("addTopSongs")) {
-//              Text("Add Track to TOP SONGS List")
-//            }
+        //        Button(
+        //            onClick = { navActions.navigateToSelectSongScreen(viewModelType.PROFILE) },
+        //            modifier = Modifier.testTag("addTopSongs")) {
+        //              Text("Add Track to TOP SONGS List")
+        //            }
 
         SongsListDisplay(
             navigationActions = navActions,
@@ -108,7 +108,8 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
               viewModel.createSpecificSongList(dialogListType) // Ensure the list is created
               viewModel.addTrackToList(dialogListType, track)
             },
-            viewModelName = viewModelType.PROFILE,)
+            viewModelName = viewModelType.PROFILE,
+        )
       }
 
   Row {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
@@ -91,15 +91,6 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
             modifier = Modifier.testTag("toggleSongList")) {
               Text(if (isTopSongsListVisible) "Show CHOSEN SONGS" else "Show TOP SONGS")
             }
-
-        // Call the SongsListDisplay function
-        // Buttons for adding tracks to top songs lists
-        //        Button(
-        //            onClick = { navActions.navigateToSelectSongScreen(viewModelType.PROFILE) },
-        //            modifier = Modifier.testTag("addTopSongs")) {
-        //              Text("Add Track to TOP SONGS List")
-        //            }
-
         SongsListDisplay(
             navigationActions = navActions,
             songLists = songLists,

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
@@ -41,6 +41,7 @@ import ch.epfl.cs311.wanderwave.ui.components.profile.ClickableIcon
 import ch.epfl.cs311.wanderwave.ui.components.profile.SelectImage
 import ch.epfl.cs311.wanderwave.ui.components.profile.SongsListDisplay
 import ch.epfl.cs311.wanderwave.ui.components.profile.VisitCard
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 
 const val SCALE_X = 0.5f
@@ -63,13 +64,13 @@ val INPUT_BOX_NAM_SIZE = 150.dp
 fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
   val currentProfileState by viewModel.profile.collectAsState()
   val songLists by viewModel.songLists.collectAsState()
-  val dialogListType by remember { mutableStateOf("TOP SONGS") }
+  val dialogListType by remember { mutableStateOf(ListType.TOP_SONGS) }
   var isTopSongsListVisible by remember { mutableStateOf(true) }
 
   val currentProfile: Profile = currentProfileState ?: return
   LaunchedEffect(Unit) {
-    viewModel.createSpecificSongList("TOP_SONGS")
-    viewModel.createSpecificSongList("CHOSEN_SONGS")
+    viewModel.createSpecificSongList(ListType.TOP_SONGS)
+    viewModel.createSpecificSongList(ListType.CHOSEN_SONGS)
   }
 
   Column(
@@ -93,18 +94,20 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
         // Call the SongsListDisplay function
         // Buttons for adding tracks to top songs lists
         Button(
-            onClick = { navActions.navigateTo(Route.SELECT_SONG) },
+            onClick = { navActions.navigateToSelectSongScreen("profile") },
             modifier = Modifier.testTag("addTopSongs")) {
               Text("Add Track to TOP SONGS List")
             }
 
         SongsListDisplay(
+            navigationActions = navActions,
             songLists = songLists,
             isTopSongsListVisible = isTopSongsListVisible,
             onAddTrack = { track ->
               viewModel.createSpecificSongList(dialogListType) // Ensure the list is created
               viewModel.addTrackToList(dialogListType, track)
-            })
+            },
+            viewModelName = "profile",)
       }
 
   Row {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
@@ -42,6 +42,7 @@ import ch.epfl.cs311.wanderwave.ui.components.profile.SelectImage
 import ch.epfl.cs311.wanderwave.ui.components.profile.SongsListDisplay
 import ch.epfl.cs311.wanderwave.ui.components.profile.VisitCard
 import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 
 const val SCALE_X = 0.5f
@@ -93,11 +94,11 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
 
         // Call the SongsListDisplay function
         // Buttons for adding tracks to top songs lists
-        Button(
-            onClick = { navActions.navigateToSelectSongScreen("profile") },
-            modifier = Modifier.testTag("addTopSongs")) {
-              Text("Add Track to TOP SONGS List")
-            }
+//        Button(
+//            onClick = { navActions.navigateToSelectSongScreen(viewModelType.PROFILE) },
+//            modifier = Modifier.testTag("addTopSongs")) {
+//              Text("Add Track to TOP SONGS List")
+//            }
 
         SongsListDisplay(
             navigationActions = navActions,
@@ -107,7 +108,7 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
               viewModel.createSpecificSongList(dialogListType) // Ensure the list is created
               viewModel.addTrackToList(dialogListType, track)
             },
-            viewModelName = "profile",)
+            viewModelName = viewModelType.PROFILE,)
       }
 
   Row {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileViewOnlyScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileViewOnlyScreen.kt
@@ -16,13 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.profile.ClickableIcon
 import ch.epfl.cs311.wanderwave.ui.components.profile.SongsListDisplay
 import ch.epfl.cs311.wanderwave.ui.components.profile.VisitCard
-import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.ui.components.utils.LoadingScreen
 import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 import ch.epfl.cs311.wanderwave.viewmodel.SongList
@@ -80,7 +80,13 @@ fun ProfileViewOnlyScreen(
             // to #127
           }
 
-          SongsListDisplay(navigationActions = navigationActions,mockSongLists, isTopSongsListVisible = true, {}, canAddSong = false,)
+          SongsListDisplay(
+              navigationActions = navigationActions,
+              mockSongLists,
+              isTopSongsListVisible = true,
+              {},
+              canAddSong = false,
+          )
         }
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileViewOnlyScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileViewOnlyScreen.kt
@@ -38,15 +38,7 @@ val mockSongLists =
             ListType.CHOSEN_SONGS,
             listOf(Track("3", "Track 3", "Artist 3"), Track("4", "Track 4", "Artist 4"))))
 // TODO: modify this, because the profile.songLists is not available yet
-/**
- * This is the screen composable which can only show the profile of the user. It includes a visit
- * card and a list of songs. This screen is not modifiable.
- *
- * @param profile The profile to display.
- * @author Menzo Bouaissi
- * @since 2.0
- * @last update 2.0
- */
+
 /**
  * This is the screen composable which can only show the profile of the user. It includes a visit
  * card and a list of songs. This screen is not modifiable.

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileViewOnlyScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileViewOnlyScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -24,6 +22,7 @@ import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.profile.ClickableIcon
 import ch.epfl.cs311.wanderwave.ui.components.profile.SongsListDisplay
 import ch.epfl.cs311.wanderwave.ui.components.profile.VisitCard
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.ui.components.utils.LoadingScreen
 import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 import ch.epfl.cs311.wanderwave.viewmodel.SongList
@@ -33,10 +32,10 @@ import kotlinx.coroutines.withContext
 val mockSongLists =
     listOf(
         SongList(
-            "TOP SONGS",
+            ListType.TOP_SONGS,
             listOf(Track("1", "Track 1", "Artist 1"), Track("2", "Track 2", "Artist 2"))),
         SongList(
-            "CHOSEN SONGS",
+            ListType.CHOSEN_SONGS,
             listOf(Track("3", "Track 3", "Artist 3"), Track("4", "Track 4", "Artist 4"))))
 // TODO: modify this, because the profile.songLists is not available yet
 /**
@@ -89,7 +88,7 @@ fun ProfileViewOnlyScreen(
             // to #127
           }
 
-          SongsListDisplay(mockSongLists, isTopSongsListVisible = true, {}, canAddSong = false)
+          SongsListDisplay(navigationActions = navigationActions,mockSongLists, isTopSongsListVisible = true, {}, canAddSong = false,)
         }
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SelectSongScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SelectSongScreen.kt
@@ -20,10 +20,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.ui.components.profile.TrackItem
-import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 
 /**
@@ -72,7 +72,8 @@ fun SelectSongScreen(navActions: NavigationActions, viewModel: SpotifySongsActio
                         viewModel.retrieveChild(listItem)
                       } else {
                         viewModel.addTrackToList(
-                            ListType.TOP_SONGS, Track(listItem.id, listItem.title, listItem.subtitle))
+                            ListType.TOP_SONGS,
+                            Track(listItem.id, listItem.title, listItem.subtitle))
                         navActions.goBack()
                       }
                     })

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SelectSongScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SelectSongScreen.kt
@@ -24,6 +24,7 @@ import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.ui.components.profile.TrackItem
 import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
+import ch.epfl.cs311.wanderwave.viewmodel.SpotifySongsActions
 
 /**
  * Screen to select a song from Spotify
@@ -36,7 +37,7 @@ import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SelectSongScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
+fun SelectSongScreen(navActions: NavigationActions, viewModel: SpotifySongsActions) {
   val mainList by viewModel.spotifySubsectionList.collectAsState()
   val childrenPlaylistTrackList by viewModel.childrenPlaylistTrackList.collectAsState()
 

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SelectSongScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SelectSongScreen.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.unit.dp
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.ui.components.profile.TrackItem
-import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
-import ch.epfl.cs311.wanderwave.viewmodel.SpotifySongsActions
+import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 
 /**
  * Screen to select a song from Spotify
@@ -72,7 +72,7 @@ fun SelectSongScreen(navActions: NavigationActions, viewModel: SpotifySongsActio
                         viewModel.retrieveChild(listItem)
                       } else {
                         viewModel.addTrackToList(
-                            "TOP SONGS", Track(listItem.id, listItem.title, listItem.subtitle))
+                            ListType.TOP_SONGS, Track(listItem.id, listItem.title, listItem.subtitle))
                         navActions.goBack()
                       }
                     })

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
@@ -22,7 +22,8 @@ import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
 import ch.epfl.cs311.wanderwave.viewmodel.TrackListViewModel
 
 @Composable
-fun TrackListScreen(navActions: NavigationActions,
+fun TrackListScreen(
+    navActions: NavigationActions,
     showMessage: (String) -> Unit,
     viewModel: TrackListViewModel = hiltViewModel()
 ) {
@@ -50,7 +51,6 @@ fun TrackListScreen(navActions: NavigationActions,
         onAddTrack = {},
         onSelectTrack = viewModel::selectTrack,
         navActions = navActions,
-        viewModelName = viewModelType.TRACKLIST
-        )
+        viewModelName = viewModelType.TRACKLIST)
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
@@ -16,11 +16,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
 import ch.epfl.cs311.wanderwave.viewmodel.TrackListViewModel
 
 @Composable
-fun TrackListScreen(
+fun TrackListScreen(navActions: NavigationActions,
     showMessage: (String) -> Unit,
     viewModel: TrackListViewModel = hiltViewModel()
 ) {
@@ -46,6 +47,9 @@ fun TrackListScreen(
         uiState.tracks,
         title = "All Tracks",
         onAddTrack = {},
-        onSelectTrack = viewModel::selectTrack)
+        onSelectTrack = viewModel::selectTrack,
+        navActions = navActions,
+        viewModelName = "trackList"
+        )
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import ch.epfl.cs311.wanderwave.model.data.viewModelType
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.ui.components.tracklist.TrackList
 import ch.epfl.cs311.wanderwave.viewmodel.TrackListViewModel
@@ -49,7 +50,7 @@ fun TrackListScreen(navActions: NavigationActions,
         onAddTrack = {},
         onSelectTrack = viewModel::selectTrack,
         navActions = navActions,
-        viewModelName = "trackList"
+        viewModelName = viewModelType.TRACKLIST
         )
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -1,6 +1,5 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.epfl.cs311.wanderwave.model.data.ListType
@@ -115,7 +114,7 @@ constructor(
    * @last update 3.0
    */
   override fun retrieveAndAddSubsection() {
-    retrieveAndAddSubsectionFromSpotify(_spotifySubsectionList, spotifyController)
+    retrieveAndAddSubsectionFromSpotify(_spotifySubsectionList, spotifyController, viewModelScope)
   }
   /**
    * Get all the element of the main screen and add them to the top list
@@ -125,8 +124,8 @@ constructor(
    * @last update 3.0
    */
   override fun retrieveChild(item: ListItem) {
-    Log.d("Test32", "retrieveChild")
-    retrieveChildFromSpotify(item, this._childrenPlaylistTrackList, spotifyController)
+    retrieveChildFromSpotify(
+        item, this._childrenPlaylistTrackList, spotifyController, viewModelScope)
   }
 
   data class UIState(

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -51,10 +51,10 @@ constructor(
   val songLists: StateFlow<List<SongList>> = _songLists
 
   private val _spotifySubsectionList = MutableStateFlow<List<ListItem>>(emptyList())
-  override val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
+  val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
 
   private val _childrenPlaylistTrackList = MutableStateFlow<List<ListItem>>(emptyList())
-  override val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
+  val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
 
   private var _uiState = MutableStateFlow(ProfileViewModel.UIState())
   val uiState: StateFlow<ProfileViewModel.UIState> = _uiState
@@ -102,7 +102,7 @@ constructor(
    *
    * @author Menzo Bouaissi
    * @since 2.0
-   * @last update 2.0
+   * @last update 3.0
    */
   override fun retrieveAndAddSubsection() {
     viewModelScope.launch {
@@ -121,7 +121,7 @@ constructor(
    *
    * @author Menzo Bouaissi
    * @since 2.0
-   * @last update 2.0
+   * @last update 3.0
    */
   override fun retrieveChild(item: ListItem) {
     viewModelScope.launch {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -23,7 +23,7 @@ class ProfileViewModel
 constructor(
     private val repository: ProfileRepository, // TODO revoir
     private val spotifyController: SpotifyController
-) : ViewModel() {
+) : ViewModel(),SpotifySongsActions {
 
   private val _profile =
       MutableStateFlow(
@@ -49,10 +49,10 @@ constructor(
   val songLists: StateFlow<List<SongList>> = _songLists
 
   private val _spotifySubsectionList = MutableStateFlow<List<ListItem>>(emptyList())
-  val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
+  override val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
 
   private val _childrenPlaylistTrackList = MutableStateFlow<List<ListItem>>(emptyList())
-  val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
+  override val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
 
   private var _uiState = MutableStateFlow(ProfileViewModel.UIState())
   val uiState: StateFlow<ProfileViewModel.UIState> = _uiState
@@ -74,7 +74,7 @@ constructor(
   }
 
   // Function to add a track to a song list
-  fun addTrackToList(listName: String, track: Track) {
+  override fun addTrackToList(listName: String, track: Track) {
     val updatedLists =
         _songLists.value.map { list ->
           if (list.name == listName) {
@@ -108,7 +108,7 @@ constructor(
    * @since 2.0
    * @last update 2.0
    */
-  fun retrieveTracks() {
+  override fun retrieveTracks() {
     viewModelScope.launch {
       val track = spotifyController.getAllElementFromSpotify().firstOrNull()
       if (track != null) {
@@ -133,7 +133,7 @@ constructor(
    * @since 2.0
    * @last update 2.0
    */
-  fun retrieveAndAddSubsection() {
+  override fun retrieveAndAddSubsection() {
     viewModelScope.launch {
       _spotifySubsectionList.value = emptyList()
       val track = spotifyController.getAllElementFromSpotify().firstOrNull()
@@ -152,7 +152,7 @@ constructor(
    * @since 2.0
    * @last update 2.0
    */
-  fun retrieveChild(item: ListItem) {
+  override fun retrieveChild(item: ListItem) {
     viewModelScope.launch {
       _childrenPlaylistTrackList.value = emptyList()
       val children = spotifyController.getAllChildren(item).firstOrNull()

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -2,11 +2,11 @@ package ch.epfl.cs311.wanderwave.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Profile
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.repository.ProfileRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
-import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 import com.spotify.protocol.types.ListItem
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -59,9 +59,8 @@ constructor(
   private var _uiState = MutableStateFlow(ProfileViewModel.UIState())
   val uiState: StateFlow<ProfileViewModel.UIState> = _uiState
 
-
   fun createSpecificSongList(listType: ListType) {
-    val listName =listType    // Check if the list already exists
+    val listName = listType // Check if the list already exists
     val existingList = _songLists.value.firstOrNull { it.name == listName }
     if (existingList == null) {
       // Add new list if it doesn't exist

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -6,6 +6,8 @@ import ch.epfl.cs311.wanderwave.model.data.Profile
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.repository.ProfileRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
+import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 import com.spotify.protocol.types.ListItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -15,7 +17,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 // Define a simple class for a song list
-data class SongList(val name: String, val tracks: List<Track> = mutableListOf())
+data class SongList(val name: ListType, val tracks: List<Track> = mutableListOf())
 
 @HiltViewModel
 class ProfileViewModel
@@ -23,7 +25,7 @@ class ProfileViewModel
 constructor(
     private val repository: ProfileRepository, // TODO revoir
     private val spotifyController: SpotifyController
-) : ViewModel(),SpotifySongsActions {
+) : ViewModel(), SpotifySongsActions {
 
   private val _profile =
       MutableStateFlow(
@@ -57,14 +59,9 @@ constructor(
   private var _uiState = MutableStateFlow(ProfileViewModel.UIState())
   val uiState: StateFlow<ProfileViewModel.UIState> = _uiState
 
-  fun createSpecificSongList(listType: String) {
-    val listName =
-        when (listType) {
-          "TOP_SONGS" -> "TOP SONGS"
-          "CHOSEN_SONGS" -> "CHOSEN SONGS"
-          else -> return // Or handle error/invalid type
-        }
-    // Check if the list already exists
+
+  fun createSpecificSongList(listType: ListType) {
+    val listName =listType    // Check if the list already exists
     val existingList = _songLists.value.firstOrNull { it.name == listName }
     if (existingList == null) {
       // Add new list if it doesn't exist
@@ -74,7 +71,7 @@ constructor(
   }
 
   // Function to add a track to a song list
-  override fun addTrackToList(listName: String, track: Track) {
+  override fun addTrackToList(listName: ListType, track: Track) {
     val updatedLists =
         _songLists.value.map { list ->
           if (list.name == listName) {
@@ -117,7 +114,7 @@ constructor(
             val children = spotifyController.getAllChildren(i).firstOrNull()
             if (children != null) {
               for (child in children) {
-                addTrackToList("TOP SONGS", Track(child.id, child.title, child.subtitle))
+                addTrackToList(ListType.TOP_SONGS, Track(child.id, child.title, child.subtitle))
               }
             }
           }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -105,31 +105,6 @@ constructor(
    * @since 2.0
    * @last update 2.0
    */
-  override fun retrieveTracks() {
-    viewModelScope.launch {
-      val track = spotifyController.getAllElementFromSpotify().firstOrNull()
-      if (track != null) {
-        for (i in track) {
-          if (i.hasChildren) {
-            val children = spotifyController.getAllChildren(i).firstOrNull()
-            if (children != null) {
-              for (child in children) {
-                addTrackToList(ListType.TOP_SONGS, Track(child.id, child.title, child.subtitle))
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Get all the element of the main screen and add them to the top list
-   *
-   * @author Menzo Bouaissi
-   * @since 2.0
-   * @last update 2.0
-   */
   override fun retrieveAndAddSubsection() {
     viewModelScope.launch {
       _spotifySubsectionList.value = emptyList()

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifySongsActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifySongsActions.kt
@@ -1,0 +1,17 @@
+package ch.epfl.cs311.wanderwave.viewmodel
+
+import ch.epfl.cs311.wanderwave.model.data.Track
+import com.spotify.protocol.types.ListItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface SpotifySongsActions {
+    val spotifySubsectionList: StateFlow<List<ListItem>>
+    val childrenPlaylistTrackList: StateFlow<List<ListItem>>
+
+    fun addTrackToList(listName: String, track: Track)
+
+    fun retrieveTracks()
+    fun retrieveAndAddSubsection()
+    fun retrieveChild(item: ListItem)
+}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -74,8 +74,10 @@ constructor(
   }
 
   override fun addTrackToList(listName: ListType, track: Track) {
-    _uiState.value.tracks += track
+    val updatedTracks = _uiState.value.tracks + track
+    _uiState.value = _uiState.value.copy(tracks = updatedTracks)
   }
+
   /**
    * Get all the element of the main screen and add them to the top list
    *
@@ -251,7 +253,7 @@ constructor(
   }
 
   data class UiState(
-      var tracks: List<Track> = listOf(),
+      val tracks: List<Track> = listOf(),
       val queue: List<Track> = listOf(),
       val loading: Boolean = false,
       val message: String? = null,

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -84,7 +84,7 @@ constructor(
    * @last update 3.0
    */
   override fun retrieveAndAddSubsection() {
-    retrieveAndAddSubsectionFromSpotify(_spotifySubsectionList, spotifyController)
+    retrieveAndAddSubsectionFromSpotify(_spotifySubsectionList, spotifyController, viewModelScope)
   }
   /**
    * Get all the element of the main screen and add them to the top list
@@ -94,7 +94,7 @@ constructor(
    * @last update 3.0
    */
   override fun retrieveChild(item: ListItem) {
-    retrieveChildFromSpotify(item, _childrenPlaylistTrackList, spotifyController)
+    retrieveChildFromSpotify(item, _childrenPlaylistTrackList, spotifyController, viewModelScope)
   }
 
   /**

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -1,12 +1,11 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.repository.TrackRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
-import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 import com.spotify.protocol.types.ListItem
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -30,7 +29,6 @@ constructor(
   val uiState: StateFlow<UiState> = _uiState
 
   private var _searchQuery = MutableStateFlow("")
-
 
   private val _spotifySubsectionList = MutableStateFlow<List<ListItem>>(emptyList())
   override val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -6,6 +6,8 @@ import ch.epfl.cs311.wanderwave.model.data.ListType
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.repository.TrackRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
+import ch.epfl.cs311.wanderwave.model.spotify.retrieveAndAddSubsectionFromSpotify
+import ch.epfl.cs311.wanderwave.model.spotify.retrieveChildFromSpotify
 import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 import com.spotify.protocol.types.ListItem
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -30,11 +32,11 @@ constructor(
 
   private var _searchQuery = MutableStateFlow("")
 
-  private val _spotifySubsectionList = MutableStateFlow<List<ListItem>>(emptyList())
-  val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
+  private var _spotifySubsectionList = MutableStateFlow<List<ListItem>>(emptyList())
+  override val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
 
-  private val _childrenPlaylistTrackList = MutableStateFlow<List<ListItem>>(emptyList())
-  val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
+  private var _childrenPlaylistTrackList = MutableStateFlow<List<ListItem>>(emptyList())
+  override val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
 
   init {
     observeTracks()
@@ -74,43 +76,25 @@ constructor(
   override fun addTrackToList(listName: ListType, track: Track) {
     _uiState.value.tracks += track
   }
-
   /**
    * Get all the element of the main screen and add them to the top list
    *
    * @author Menzo Bouaissi
-   * @since 3.0
+   * @since 2.0
    * @last update 3.0
    */
   override fun retrieveAndAddSubsection() {
-    viewModelScope.launch {
-      _spotifySubsectionList.value = emptyList()
-      val track = spotifyController.getAllElementFromSpotify().firstOrNull()
-      if (track != null) {
-        for (i in track) {
-          _spotifySubsectionList.value += i
-        }
-      }
-    }
+    retrieveAndAddSubsectionFromSpotify(_spotifySubsectionList, spotifyController)
   }
-
   /**
    * Get all the element of the main screen and add them to the top list
    *
    * @author Menzo Bouaissi
-   * @since 3.0
+   * @since 2.0
    * @last update 3.0
    */
   override fun retrieveChild(item: ListItem) {
-    viewModelScope.launch {
-      _childrenPlaylistTrackList.value = emptyList()
-      val children = spotifyController.getAllChildren(item).firstOrNull()
-      if (children != null) {
-        for (child in children) {
-          _childrenPlaylistTrackList.value += child
-        }
-      }
-    }
+    retrieveChildFromSpotify(item, _childrenPlaylistTrackList, spotifyController)
   }
 
   /**

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -1,5 +1,6 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.epfl.cs311.wanderwave.model.data.Track
@@ -75,42 +76,6 @@ constructor(
   override fun addTrackToList(listName: ListType, track: Track) {
     _uiState.value.tracks += track
 
-
-//    val updatedLists =
-//      _songLists.value.map { list ->
-//        if (list.name == listName) {
-//          if (list.tracks.contains(track)) return@map list
-//
-//          list.copy(tracks = ArrayList(list.tracks).apply { add(track) })
-//        } else {
-//          list
-//        }
-//      }
-//    _songLists.value = updatedLists
-  }
-  /**
-   * Get all the element of the main screen and add them to the top list
-   *
-   * @author Menzo Bouaissi
-   * @since 2.0
-   * @last update 2.0
-   */
-  override fun retrieveTracks() {
-    viewModelScope.launch {
-      val track = spotifyController.getAllElementFromSpotify().firstOrNull()
-      if (track != null) {
-        for (i in track) {
-          if (i.hasChildren) {
-            val children = spotifyController.getAllChildren(i).firstOrNull()
-            if (children != null) {
-              for (child in children) {
-                addTrackToList(ListType.TOP_SONGS, Track(child.id, child.title, child.subtitle))
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
   /**

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -75,15 +75,14 @@ constructor(
 
   override fun addTrackToList(listName: ListType, track: Track) {
     _uiState.value.tracks += track
-
   }
 
   /**
    * Get all the element of the main screen and add them to the top list
    *
    * @author Menzo Bouaissi
-   * @since 2.0
-   * @last update 2.0
+   * @since 3.0
+   * @last update 3.0
    */
   override fun retrieveAndAddSubsection() {
     viewModelScope.launch {
@@ -101,8 +100,8 @@ constructor(
    * Get all the element of the main screen and add them to the top list
    *
    * @author Menzo Bouaissi
-   * @since 2.0
-   * @last update 2.0
+   * @since 3.0
+   * @last update 3.0
    */
   override fun retrieveChild(item: ListItem) {
     viewModelScope.launch {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -31,10 +31,10 @@ constructor(
   private var _searchQuery = MutableStateFlow("")
 
   private val _spotifySubsectionList = MutableStateFlow<List<ListItem>>(emptyList())
-  override val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
+  val spotifySubsectionList: StateFlow<List<ListItem>> = _spotifySubsectionList
 
   private val _childrenPlaylistTrackList = MutableStateFlow<List<ListItem>>(emptyList())
-  override val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
+  val childrenPlaylistTrackList: StateFlow<List<ListItem>> = _childrenPlaylistTrackList
 
   init {
     observeTracks()

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
@@ -1,49 +1,50 @@
 package ch.epfl.cs311.wanderwave.viewmodel.interfaces
 
-import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.data.ListType
+import ch.epfl.cs311.wanderwave.model.data.Track
 import com.spotify.protocol.types.ListItem
 import kotlinx.coroutines.flow.StateFlow
 
 interface SpotifySongsActions {
-    /**
-     * The list of subsections of the user's top songs. Each subsection is a list of tracks or playlist.
-     */
-    val spotifySubsectionList: StateFlow<List<ListItem>>
+  /**
+   * The list of subsections of the user's top songs. Each subsection is a list of tracks or
+   * playlist.
+   */
+  val spotifySubsectionList: StateFlow<List<ListItem>>
 
-    /**
-     * The list child in the subsections of the user's top songs. Each child is a list of tracks or playlist.
-     */
-    val childrenPlaylistTrackList: StateFlow<List<ListItem>>
+  /**
+   * The list child in the subsections of the user's top songs. Each child is a list of tracks or
+   * playlist.
+   */
+  val childrenPlaylistTrackList: StateFlow<List<ListItem>>
 
-    /**
-     * Add a track to the list of the user's list. The list is specified by the listName parameter.
-     *
-     * @param listName The list to add the track to.
-     * @param track The track to add to the list.
-     * @author Menzo Bouaissi
-     * @since 3.0
-     * @last update 3.0
-     *
-     */
-    fun addTrackToList(listName: ListType = ListType.TOP_SONGS, track: Track)
+  /**
+   * Add a track to the list of the user's list. The list is specified by the listName parameter.
+   *
+   * @param listName The list to add the track to.
+   * @param track The track to add to the list.
+   * @author Menzo Bouaissi
+   * @since 3.0
+   * @last update 3.0
+   */
+  fun addTrackToList(listName: ListType = ListType.TOP_SONGS, track: Track)
 
-    /**
-     * Get all the element of the main screen and add them to the spotifySubsectionList
-     *
-     * @author Menzo Bouaissi
-     * @since 3.0
-     * @last update 3.0
-     */
-    fun retrieveAndAddSubsection()
+  /**
+   * Get all the element of the main screen and add them to the spotifySubsectionList
+   *
+   * @author Menzo Bouaissi
+   * @since 3.0
+   * @last update 3.0
+   */
+  fun retrieveAndAddSubsection()
 
-    /**
-     * Get all the element of a subsection and add them to the childrenPlaylistTrackList
-     *
-     * @param item The item to retrieve the children from.
-     * @author Menzo Bouaissi
-     * @since 3.0
-     * @last update 3.0
-     */
-    fun retrieveChild(item: ListItem)
+  /**
+   * Get all the element of a subsection and add them to the childrenPlaylistTrackList
+   *
+   * @param item The item to retrieve the children from.
+   * @author Menzo Bouaissi
+   * @since 3.0
+   * @last update 3.0
+   */
+  fun retrieveChild(item: ListItem)
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
@@ -1,15 +1,15 @@
-package ch.epfl.cs311.wanderwave.viewmodel
+package ch.epfl.cs311.wanderwave.viewmodel.interfaces
 
 import ch.epfl.cs311.wanderwave.model.data.Track
+import ch.epfl.cs311.wanderwave.model.data.ListType
 import com.spotify.protocol.types.ListItem
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 interface SpotifySongsActions {
     val spotifySubsectionList: StateFlow<List<ListItem>>
     val childrenPlaylistTrackList: StateFlow<List<ListItem>>
 
-    fun addTrackToList(listName: String, track: Track)
+    fun addTrackToList(listName: ListType = ListType.TOP_SONGS, track: Track)
 
     fun retrieveTracks()
     fun retrieveAndAddSubsection()

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface SpotifySongsActions {
 
+  val spotifySubsectionList: StateFlow<List<ListItem>>
+  val childrenPlaylistTrackList: StateFlow<List<ListItem>>
   /**
    * Add a track to the list of the user's list. The list is specified by the listName parameter.
    *

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
@@ -6,12 +6,44 @@ import com.spotify.protocol.types.ListItem
 import kotlinx.coroutines.flow.StateFlow
 
 interface SpotifySongsActions {
+    /**
+     * The list of subsections of the user's top songs. Each subsection is a list of tracks or playlist.
+     */
     val spotifySubsectionList: StateFlow<List<ListItem>>
+
+    /**
+     * The list child in the subsections of the user's top songs. Each child is a list of tracks or playlist.
+     */
     val childrenPlaylistTrackList: StateFlow<List<ListItem>>
 
+    /**
+     * Add a track to the list of the user's list. The list is specified by the listName parameter.
+     *
+     * @param listName The list to add the track to.
+     * @param track The track to add to the list.
+     * @author Menzo Bouaissi
+     * @since 3.0
+     * @last update 3.0
+     *
+     */
     fun addTrackToList(listName: ListType = ListType.TOP_SONGS, track: Track)
 
-    fun retrieveTracks()
+    /**
+     * Get all the element of the main screen and add them to the spotifySubsectionList
+     *
+     * @author Menzo Bouaissi
+     * @since 3.0
+     * @last update 3.0
+     */
     fun retrieveAndAddSubsection()
+
+    /**
+     * Get all the element of a subsection and add them to the childrenPlaylistTrackList
+     *
+     * @param item The item to retrieve the children from.
+     * @author Menzo Bouaissi
+     * @since 3.0
+     * @last update 3.0
+     */
     fun retrieveChild(item: ListItem)
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/interfaces/SpotifySongsActions.kt
@@ -6,17 +6,6 @@ import com.spotify.protocol.types.ListItem
 import kotlinx.coroutines.flow.StateFlow
 
 interface SpotifySongsActions {
-  /**
-   * The list of subsections of the user's top songs. Each subsection is a list of tracks or
-   * playlist.
-   */
-  val spotifySubsectionList: StateFlow<List<ListItem>>
-
-  /**
-   * The list child in the subsections of the user's top songs. Each child is a list of tracks or
-   * playlist.
-   */
-  val childrenPlaylistTrackList: StateFlow<List<ListItem>>
 
   /**
    * Add a track to the list of the user's list. The list is specified by the listName parameter.


### PR DESCRIPTION
This PR enable the possibility for the user to navigate to the select song screen from the tracklist screen, and add playlist  from spotify to the list on the track list screen. Also it makes some part of the code cleaner, like using enum instead of strings, remove stale functions, ...

Closes #247 