### PR TITLE
Solve the naviagation bug + quality of life update

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/EditProfileTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/EditProfileTest.kt
@@ -114,7 +114,7 @@ class EditProfileTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
       saveButton {
         assertIsDisplayed()
         performClick()
-        verify { mockNavigationActions.navigateToTopLevel(Route.PROFILE) }
+        verify { mockNavigationActions.goBack() }
       }
     }
   }
@@ -125,7 +125,7 @@ class EditProfileTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
       cancelButton {
         assertIsDisplayed()
         performClick()
-        verify { mockNavigationActions.navigateToTopLevel(Route.PROFILE) }
+        verify { mockNavigationActions.goBack() }
       }
     }
   }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/ImagesActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/ImagesActions.kt
@@ -1,7 +1,6 @@
 package ch.epfl.cs311.wanderwave.ui.components.profile
 
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -11,6 +10,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -28,20 +31,16 @@ import coil.compose.AsyncImage
  * @param profile the profile of the user
  * @author Menzo Bouaissi
  * @since 1.0
- * @last update 1.0
+ * @last update 3.0
  */
 @Composable
-fun SelectImage(modifier: Modifier, profile: Profile) {
-  Log.d("SelectImage", profile.profilePictureUri.toString())
-  if (profile.profilePictureUri != null && profile.profilePictureUri.toString() != "") {
-    AsyncImage(
-        model = profile.profilePictureUri,
-        contentDescription = "Profile picture",
-        modifier = modifier)
+fun SelectImage(modifier: Modifier, imageUri: Uri?) {
+  if (imageUri != null) {
+    AsyncImage(model = imageUri, contentDescription = "Profile picture", modifier = modifier)
   } else {
     Image(
         painter = painterResource(id = R.drawable.profile_picture),
-        contentDescription = "Profile picture",
+        contentDescription = "Default profile picture",
         modifier = modifier)
   }
 }
@@ -53,18 +52,21 @@ fun SelectImage(modifier: Modifier, profile: Profile) {
  * @param onImageChange enable to transmit the changed to the caller
  * @author Menzo Bouaissi
  * @since 1.0
- * @last update 1.0
+ * @last update 3.0
  */
 @Composable
 fun ImageSelection(profile: Profile, onImageChange: (Uri?) -> Unit) {
-  // var imageUri by remember { mutableStateOf<Uri?>(null) }
+  var imageUri by remember { mutableStateOf(profile.profilePictureUri) }
+
   val launcher =
       rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri: Uri?
         ->
-        if (uri != null) profile.copy(profilePictureUri = uri)
+        imageUri = uri
         onImageChange(uri)
       }
+
   Box(modifier = Modifier.fillMaxWidth()) {
+    // Pass `imageUri` directly to `AsyncImage`
     SelectImage(
         modifier =
             Modifier.padding(top = 48.dp, bottom = 48.dp, start = 16.dp, end = 0.dp)
@@ -72,6 +74,6 @@ fun ImageSelection(profile: Profile, onImageChange: (Uri?) -> Unit) {
                 .clickable { launcher.launch("image/*") }
                 .align(Alignment.Center)
                 .testTag("profilePicture"),
-        profile = profile)
+        imageUri = imageUri)
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/VisitCards.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/profile/VisitCards.kt
@@ -31,7 +31,7 @@ fun VisitCard(modifier: Modifier = Modifier, profile: Profile) {
                 .padding(top = 48.dp, bottom = 48.dp, start = 16.dp, end = 0.dp)
                 .size(width = 150.dp, height = 100.dp)
                 .testTag("profilePicture"),
-        profile = profile)
+        imageUri = profile.profilePictureUri)
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/BeaconScreen.kt
@@ -249,7 +249,7 @@ internal fun TrackItem(
                             }
                           }
                         }),
-            profile = profileAndTrack.profile,
+            imageUri = profileAndTrack.profile.profilePictureUri,
         )
       }
     }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/EditProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/EditProfileScreen.kt
@@ -80,21 +80,13 @@ fun EditProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel
                   )
 
               viewModel.updateProfile(profileCopy)
-              navActions.navigateToTopLevel(Route.PROFILE)
+              navActions.goBack()
             },
-            onCancel = { navActions.navigateToTopLevel(Route.PROFILE) })
-
-        Spacer(Modifier.padding(18.dp))
-        Button(
-            onClick = {
+            onCancel = { navActions.goBack() },
+            onDelete = {
               viewModel.deleteProfile()
               navActions.navigateToTopLevel(Route.LOGIN)
-            },
-            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-            border = BorderStroke(1.dp, md_theme_light_error),
-            modifier = Modifier.width(100.dp).testTag("deleteButton")) {
-              Text(text = "Delete profile", color = md_theme_light_error)
-            }
+            })
       }
 }
 
@@ -166,7 +158,7 @@ fun EditableTextFields(
  * @last update 1.0
  */
 @Composable
-fun ActionButtons(onSave: () -> Unit, onCancel: () -> Unit) {
+fun ActionButtons(onSave: () -> Unit, onCancel: () -> Unit, onDelete: () -> Unit) {
   Column(
       verticalArrangement = Arrangement.spacedBy(2.dp),
       horizontalAlignment = Alignment.CenterHorizontally) {
@@ -175,7 +167,6 @@ fun ActionButtons(onSave: () -> Unit, onCancel: () -> Unit) {
             colors = ButtonDefaults.buttonColors(containerColor = md_theme_light_primary),
             modifier = Modifier.width(100.dp).testTag("saveButton")) {
               Text("Save")
-              // TODO: Send the data to the server
             }
         Spacer(modifier = Modifier.width(8.dp))
         Button(
@@ -184,6 +175,14 @@ fun ActionButtons(onSave: () -> Unit, onCancel: () -> Unit) {
             border = BorderStroke(1.dp, md_theme_light_error),
             modifier = Modifier.width(100.dp).testTag("cancelButton")) {
               Text(text = "Cancel", color = md_theme_light_error)
+            }
+        Spacer(Modifier.padding(8.dp))
+        Button(
+            onClick = onDelete,
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+            border = BorderStroke(1.dp, md_theme_light_error),
+            modifier = Modifier.width(200.dp).testTag("deleteButton")) {
+              Text(text = "Delete profile", color = md_theme_light_error)
             }
       }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
@@ -174,7 +174,9 @@ fun ProfileButton(
               .padding(16.dp)
               .testTag("profileButton")) {
         if (navActions.getCurrentRoute() == Route.MAIN) {
-          SelectImage(modifier = Modifier.clip(CircleShape).size(50.dp), profile = currentProfile)
+          SelectImage(
+              modifier = Modifier.clip(CircleShape).size(50.dp),
+              imageUri = currentProfile?.profilePictureUri)
         }
       }
 }


### PR DESCRIPTION
This PR aims to : 

1.  Solve a bug about the edit profile screen, where when the user click on cancel or save, the navigation wasn't working. 
2. Improve the "quality of life". So now, when a user select a picture, he can directly see it, and decide if we want's to save his profile or cancel the modification. (Before the user needed to save his profile and go back to the profile screen so he could see the new image)