### PR TITLE
delete add profiles if not exist

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/model/ProfileConnectionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/model/ProfileConnectionTest.kt
@@ -118,23 +118,6 @@ public class ProfileConnectionTest {
   }
 
   @Test
-  fun testAddProfilesIfNotExist() {
-    val profiles =
-        listOf(
-            Profile(
-                firstName = "New",
-                lastName = "User",
-                description = "No description",
-                numberOfLikes = 0,
-                isPublic = false,
-                spotifyUid = "newspotifyUid",
-                firebaseUid = "newfirebaseUid"))
-
-    every { querySnapshot.isEmpty } returns true
-    profileConnection.addProfilesIfNotExist(profiles)
-  }
-
-  @Test
   fun testAddItem() {
     val profile =
         Profile(

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/BeaconConnection.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/BeaconConnection.kt
@@ -42,7 +42,6 @@ class BeaconConnection(
   override fun addItem(item: Beacon) {
     super.addItem(item)
     trackConnection.addItemsIfNotExist(item.profileAndTrack.map { it.track })
-    Log.d("BeaconConnection", "Beacon added successfully")
   }
 
   override fun addItemWithId(item: Beacon) {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/BeaconConnection.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/BeaconConnection.kt
@@ -42,20 +42,17 @@ class BeaconConnection(
   override fun addItem(item: Beacon) {
     super.addItem(item)
     trackConnection.addItemsIfNotExist(item.profileAndTrack.map { it.track })
-    profileConnection.addProfilesIfNotExist(item.profileAndTrack.map { it.profile })
     Log.d("BeaconConnection", "Beacon added successfully")
   }
 
   override fun addItemWithId(item: Beacon) {
     super.addItemWithId(item)
     trackConnection.addItemsIfNotExist(item.profileAndTrack.map { it.track })
-    profileConnection.addProfilesIfNotExist(item.profileAndTrack.map { it.profile })
   }
 
   override fun updateItem(item: Beacon) {
     super.updateItem(item)
     trackConnection.addItemsIfNotExist(item.profileAndTrack.map { it.track })
-    profileConnection.addProfilesIfNotExist(item.profileAndTrack.map { it.profile })
   }
 
   override fun documentTransform(document: DocumentSnapshot, dataFlow: MutableStateFlow<Beacon?>) {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/ProfileConnection.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/ProfileConnection.kt
@@ -62,21 +62,6 @@ class ProfileConnection(
     trackConnection.addItemsIfNotExist(item.chosenSongs)
   }
 
-  fun addProfilesIfNotExist(profiles: List<Profile?>) {
-    coroutineScope.launch {
-      profiles.filterNotNull().forEach { profile ->
-        val querySnapshot =
-            db.collection(collectionName)
-                .whereEqualTo("firebaseUid", profile.firebaseUid)
-                .get()
-                .await()
-        if (querySnapshot.isEmpty) {
-          addItemWithId(profile)
-        }
-      }
-    }
-  }
-
   override fun documentTransform(document: DocumentSnapshot, dataFlow: MutableStateFlow<Profile?>) {
     val profile = dataFlow.value ?: Profile.from(document)
 

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/TrackConnection.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/TrackConnection.kt
@@ -77,10 +77,7 @@ class TrackConnection(private val database: FirebaseFirestore) :
           return@withContext null
         }
 
-        ProfileTrackAssociation(
-            profile = profile ?: null,
-            track = track!!
-        )
+        ProfileTrackAssociation(profile = profile ?: null, track = track!!)
       } catch (e: Exception) {
         // Handle exceptions
         Log.e("Firestore", "Error fetching track:${e.message}")

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/TrackConnection.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/TrackConnection.kt
@@ -72,14 +72,15 @@ class TrackConnection(private val database: FirebaseFirestore) :
         trackDocument?.let { track = Track.from(it) }
         val profileDocument = profileAndTrackRef["creator"]?.get()?.await()
         profileDocument?.let { profile = Profile.from(it) }
-        if (profile == null || track == null) {
-          Log.e("Firestore", "Error fetching profile or track, firebase format is wrong")
+        if (profile == null) {
+          Log.e("Firestore", "Error fetching the track, firebase format is wrong")
           return@withContext null
         }
 
         ProfileTrackAssociation(
-            profile = profileDocument?.let { Profile.from(it) }!!,
-            track = trackDocument?.let { Track.from(it) }!!)
+            profile = profile ?: null,
+            track = track!!
+        )
       } catch (e: Exception) {
         // Handle exceptions
         Log.e("Firestore", "Error fetching track:${e.message}")


### PR DESCRIPTION
This PR delete the function we created for testing for the beacon connection that add a profile if it doesn't exist, now as the profile in the track profile association can be null, we don't have any problems any more. And as yoric is going to connect the profiles to the function, it should work flowlessly.