### PR TITLE
Revert " save the profile in firebase"

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModelTest.kt
@@ -1,9 +1,7 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
-import androidx.compose.material3.SnackbarHostState
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.cs311.wanderwave.model.data.ListType
-import ch.epfl.cs311.wanderwave.model.data.Profile
 import ch.epfl.cs311.wanderwave.model.data.Track
 import ch.epfl.cs311.wanderwave.model.remote.ProfileConnection
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
@@ -13,7 +11,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
@@ -118,47 +115,5 @@ class ProfileViewModelTest {
 
     assertEquals(expectedListItem, result?.get(0))
     assertEquals(expectedListItem, result2?.get(0))
-  }
-
-  @Test
-  fun testLoadProfile() = runBlockingTest {
-    // Setup mock responses
-    val spotifyUid = "existingSpotifyUid"
-    val expectedProfile =
-        Profile(
-            firstName = "First",
-            lastName = "Last",
-            description = "A description",
-            numberOfLikes = 10,
-            isPublic = true,
-            spotifyUid = spotifyUid,
-            firebaseUid = "firebaseUid",
-        )
-    val nonExistingSpotifyUid = "nonExistingSpotifyUid"
-    val snackbarHostState = SnackbarHostState()
-    val scope = CoroutineScope(testDispatcher)
-
-    every { profileRepository.isUidExisting(spotifyUid, any()) } answers
-        {
-          val callback = arg<(Boolean, Profile?) -> Unit>(1)
-          callback(true, expectedProfile)
-        }
-
-    every { profileRepository.isUidExisting(nonExistingSpotifyUid, any()) } answers
-        {
-          val callback = arg<(Boolean, Profile?) -> Unit>(1)
-          callback(false, null)
-        }
-    assertEquals("My FirstName", viewModel.profile.value.firstName)
-
-    viewModel.loadProfile(spotifyUid, snackbarHostState, scope)
-    advanceUntilIdle()
-
-    assertEquals(expectedProfile, viewModel.profile.value)
-
-    viewModel.loadProfile(nonExistingSpotifyUid, snackbarHostState, scope)
-    advanceUntilIdle()
-
-    assertEquals(1, snackbarHostState.currentSnackbarData?.dismiss()?.let { 1 } ?: 0)
   }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/ProfileConnection.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/remote/ProfileConnection.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class ProfileConnection(
     private val database: FirebaseFirestore,

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/ProfileViewModel.kt
@@ -1,6 +1,5 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
-import androidx.compose.material3.SnackbarHostState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.epfl.cs311.wanderwave.model.data.ListType
@@ -14,9 +13,9 @@ import ch.epfl.cs311.wanderwave.viewmodel.interfaces.SpotifySongsActions
 import com.spotify.protocol.types.ListItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 // Define a simple class for a song list
@@ -26,7 +25,7 @@ data class SongList(val name: ListType, val tracks: List<Track> = mutableListOf(
 class ProfileViewModel
 @Inject
 constructor(
-    private val repository: ProfileRepository,
+    private val repository: ProfileRepository, // TODO revoir
     private val spotifyController: SpotifyController
 ) : ViewModel(), SpotifySongsActions {
 
@@ -89,11 +88,11 @@ constructor(
 
   fun updateProfile(updatedProfile: Profile) {
     _profile.value = updatedProfile
-    viewModelScope.launch { repository.updateItem(updatedProfile) }
+    repository.updateItem(updatedProfile)
   }
 
   fun deleteProfile() {
-    viewModelScope.launch { repository.deleteItem(_profile.value) }
+    repository.deleteItem(_profile.value)
   }
 
   fun togglePublicMode() {
@@ -107,20 +106,6 @@ constructor(
       }
     }
   }
-
-  fun loadProfile(spotifyUid: String, snackbarHostState: SnackbarHostState, scope: CoroutineScope) {
-    viewModelScope.launch {
-      repository.isUidExisting(spotifyUid) { exists, profile ->
-        if (exists && profile != null) {
-          _profile.value = profile
-        } else {
-          // Show a snackbar message if the profile does not exist
-          scope.launch { snackbarHostState.showSnackbar("Profile does not exist.") }
-        }
-      }
-    }
-  }
-
   /**
    * Get all the element of the main screen and add them to the top list
    *


### PR DESCRIPTION
Reverts G12-Wanderwave/Wanderwave#294

This conflicts with #292 which was already merged into the feature branch `feature/link-profile-to-auth` before, and implements just a subset of it.