### PR TITLE
show recently played tracks on the tracklistScreen when toggled

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModelTest.kt
@@ -11,6 +11,7 @@ import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -371,6 +372,8 @@ class TrackListViewModelTest {
 
   @Test
   fun toggleTrackSourceTest() = run {
+    every { mockSpotifyController.recentlyPlayedTracks } returns
+        MutableStateFlow(emptyList<Track>())
     val initial = viewModel.uiState.value.showRecentlyAdded
     viewModel.toggleTrackSource()
     val toggled = viewModel.uiState.value.showRecentlyAdded

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
@@ -20,10 +20,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.isActive
 import kotlinx.coroutines.launch
 
 class SpotifyController(private val context: Context) {
+  val recentlyPlayedTracks = MutableStateFlow(emptyList<Track>())
 
   private val CLIENT_ID = BuildConfig.SPOTIFY_CLIENT_ID
   private val REDIRECT_URI = "wanderwave-auth://callback"
@@ -116,6 +119,8 @@ class SpotifyController(private val context: Context) {
                 startPlaybackTimer(it.track.duration)
               }
               trySend(true)
+              // prepend to the start of the recently played tracks list
+              recentlyPlayedTracks.value = listOf(track) + recentlyPlayedTracks.value.filterNot { it.id == track.id }
             }
             .setErrorCallback {
               Log.e("SpotifyController", "Failed to play track: ${track.title}")

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -29,6 +29,10 @@ constructor(
 
   private var _searchQuery = MutableStateFlow("")
 
+  fun recentTracks(): StateFlow<List<Track>> {
+    return spotifyController.recentlyPlayedTracks
+  }
+
   fun toggleTrackSource() {
     _uiState.value = _uiState.value.copy(showRecentlyAdded = !_uiState.value.showRecentlyAdded)
     loadTracksBasedOnSource()
@@ -40,7 +44,7 @@ constructor(
       if (_uiState.value.showRecentlyAdded) {
         loadRecentlyAddedTracks()
       } else {
-        _uiState.value = _uiState.value.copy(tracks = listOf(), loading = false)
+        _uiState.value = _uiState.value.copy(tracks = spotifyController.recentlyPlayedTracks.value)
       }
     }
   }


### PR DESCRIPTION
When listening to a song, the spotifyController now remembers it and adds the song to a list.
On the track list screen, one can toggle the switch to show the songs recently listened to. This list is also playable, so we can listen to recent tracks from there.