### PR TITLE
 handling first time a user create profile

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/SpotifyConnectScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/SpotifyConnectScreenTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.screens.SpotifyConnectScreen
-import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 import ch.epfl.cs311.wanderwave.viewmodel.SpotifyConnectScreenViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
@@ -31,20 +30,10 @@ class SpotifyConnectScreenTest :
 
   @RelaxedMockK private lateinit var mockViewModel: SpotifyConnectScreenViewModel
 
-  @RelaxedMockK private lateinit var mockProfileViewModel: ProfileViewModel
-
-  private fun setup(
-      uiState: SpotifyConnectScreenViewModel.UiState,
-      profileUiState: ProfileViewModel.UIState = ProfileViewModel.UIState()
-  ) {
+  private fun setup(uiState: SpotifyConnectScreenViewModel.UiState) {
     every { mockViewModel.uiState } returns MutableStateFlow(uiState)
-    every { mockProfileViewModel.uiState } returns MutableStateFlow(profileUiState)
-
     composeTestRule.setContent {
-      SpotifyConnectScreen(
-          navigationActions = mockNavigationActions,
-          viewModel = mockViewModel,
-          profileViewModel = mockProfileViewModel)
+      SpotifyConnectScreen(navigationActions = mockNavigationActions, viewModel = mockViewModel)
     }
   }
 

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/SpotifyConnectScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/SpotifyConnectScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.screens.SpotifyConnectScreen
+import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 import ch.epfl.cs311.wanderwave.viewmodel.SpotifyConnectScreenViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
@@ -30,10 +31,20 @@ class SpotifyConnectScreenTest :
 
   @RelaxedMockK private lateinit var mockViewModel: SpotifyConnectScreenViewModel
 
-  private fun setup(uiState: SpotifyConnectScreenViewModel.UiState) {
+  @RelaxedMockK private lateinit var mockProfileViewModel: ProfileViewModel
+
+  private fun setup(
+      uiState: SpotifyConnectScreenViewModel.UiState,
+      profileUiState: ProfileViewModel.UIState = ProfileViewModel.UIState()
+  ) {
     every { mockViewModel.uiState } returns MutableStateFlow(uiState)
+    every { mockProfileViewModel.uiState } returns MutableStateFlow(profileUiState)
+
     composeTestRule.setContent {
-      SpotifyConnectScreen(navigationActions = mockNavigationActions, viewModel = mockViewModel)
+      SpotifyConnectScreen(
+          navigationActions = mockNavigationActions,
+          viewModel = mockViewModel,
+          profileViewModel = mockProfileViewModel)
     }
   }
 

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifyConnectScreenViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifyConnectScreenViewModelTest.kt
@@ -1,6 +1,7 @@
 package ch.epfl.cs311.wanderwave.viewmodel
 
 import ch.epfl.cs311.wanderwave.model.auth.AuthenticationController
+import ch.epfl.cs311.wanderwave.model.repository.ProfileRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
 import io.mockk.called
 import io.mockk.coEvery
@@ -24,6 +25,7 @@ class SpotifyConnectScreenViewModelTest {
   @RelaxedMockK private lateinit var mockSpotifyController: SpotifyController
 
   @RelaxedMockK private lateinit var mockAuthenticationController: AuthenticationController
+  @RelaxedMockK private lateinit var mockProfileRepository: ProfileRepository
 
   private lateinit var viewModel: SpotifyConnectScreenViewModel
 
@@ -36,7 +38,9 @@ class SpotifyConnectScreenViewModelTest {
     every { mockAuthenticationController.isSignedIn() } returns isSignedIn
     coEvery { mockAuthenticationController.refreshTokenIfNecessary() } returns
         (isSignedIn || canRefresh)
-    viewModel = SpotifyConnectScreenViewModel(mockSpotifyController, mockAuthenticationController)
+    viewModel =
+        SpotifyConnectScreenViewModel(
+            mockSpotifyController, mockAuthenticationController, mockProfileRepository)
   }
 
   @Test

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/EditProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/EditProfileScreen.kt
@@ -44,7 +44,11 @@ import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
  * @last update 1.0
  */
 @Composable
-fun EditProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
+fun EditProfileScreen(
+    navActions: NavigationActions,
+    viewModel: ProfileViewModel,
+    canCancel: Boolean = true
+) {
   val profile by viewModel.profile.collectAsState()
   val profile2 = profile.copy()
   var firstName by remember { mutableStateOf(profile2.firstName) }
@@ -85,11 +89,12 @@ fun EditProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel
               viewModel.updateProfile(profileCopy)
               navActions.goBack()
             },
-            onCancel = { navActions.goBack() },
+            onCancel = { if (canCancel) navActions.goBack() },
             onDelete = {
               viewModel.deleteProfile()
               navActions.navigateToTopLevel(Route.LOGIN)
-            })
+            },
+            canCancel = canCancel)
       }
 }
 
@@ -161,7 +166,12 @@ fun EditableTextFields(
  * @last update 1.0
  */
 @Composable
-fun ActionButtons(onSave: () -> Unit, onCancel: () -> Unit, onDelete: () -> Unit) {
+fun ActionButtons(
+    onSave: () -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit,
+    canCancel: Boolean = true
+) {
   Column(
       verticalArrangement = Arrangement.spacedBy(2.dp),
       horizontalAlignment = Alignment.CenterHorizontally) {
@@ -172,20 +182,22 @@ fun ActionButtons(onSave: () -> Unit, onCancel: () -> Unit, onDelete: () -> Unit
               Text("Save")
             }
         Spacer(modifier = Modifier.width(8.dp))
-        Button(
-            onClick = onCancel,
-            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-            border = BorderStroke(1.dp, md_theme_light_error),
-            modifier = Modifier.width(100.dp).testTag("cancelButton")) {
-              Text(text = "Cancel", color = md_theme_light_error)
-            }
-        Spacer(Modifier.padding(8.dp))
-        Button(
-            onClick = onDelete,
-            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-            border = BorderStroke(1.dp, md_theme_light_error),
-            modifier = Modifier.width(200.dp).testTag("deleteButton")) {
-              Text(text = "Delete profile", color = md_theme_light_error)
-            }
+        if (canCancel) {
+          Button(
+              onClick = onCancel,
+              colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+              border = BorderStroke(1.dp, md_theme_light_error),
+              modifier = Modifier.width(100.dp).testTag("cancelButton")) {
+                Text(text = "Cancel", color = md_theme_light_error)
+              }
+          Spacer(Modifier.padding(8.dp))
+          Button(
+              onClick = onDelete,
+              colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+              border = BorderStroke(1.dp, md_theme_light_error),
+              modifier = Modifier.width(200.dp).testTag("deleteButton")) {
+                Text(text = "Delete profile", color = md_theme_light_error)
+              }
+        }
       }
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SpotifyConnectScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SpotifyConnectScreen.kt
@@ -10,24 +10,40 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.utils.LoadingScreen
+import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 import ch.epfl.cs311.wanderwave.viewmodel.SpotifyConnectScreenViewModel
 
 @Composable
 fun SpotifyConnectScreen(
     navigationActions: NavigationActions,
-    viewModel: SpotifyConnectScreenViewModel = hiltViewModel()
+    viewModel: SpotifyConnectScreenViewModel = hiltViewModel(),
+    profileViewModel: ProfileViewModel = hiltViewModel()
 ) {
   val state by viewModel.uiState.collectAsStateWithLifecycle()
 
   LaunchedEffect(state) {
     if (state.hasResult) {
       if (state.success) {
-        navigationActions.navigateToTopLevel(Route.MAP)
+        profileViewModel.getProfileOfCurrentUser(false)
+        val profileResult = profileViewModel.uiState.value.error
+        if (profileResult == "Document does not exist") {
+          viewModel.updateState(success = true, isFirstTime = true)
+        } else {
+          viewModel.updateState(success = true, isFirstTime = false)
+        }
       } else {
         navigationActions.navigateToTopLevel(Route.LOGIN)
       }
     } else {
       viewModel.connectRemote()
+    }
+  }
+
+  if (state.hasResult && state.success) {
+    if (state.isFirstTime) {
+      navigationActions.navigateToTopLevel(Route.EDIT_PROFILE)
+    } else {
+      navigationActions.navigateToTopLevel(Route.MAP)
     }
   }
 

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SpotifyConnectScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/SpotifyConnectScreen.kt
@@ -10,40 +10,29 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import ch.epfl.cs311.wanderwave.navigation.NavigationActions
 import ch.epfl.cs311.wanderwave.navigation.Route
 import ch.epfl.cs311.wanderwave.ui.components.utils.LoadingScreen
-import ch.epfl.cs311.wanderwave.viewmodel.ProfileViewModel
 import ch.epfl.cs311.wanderwave.viewmodel.SpotifyConnectScreenViewModel
 
 @Composable
 fun SpotifyConnectScreen(
     navigationActions: NavigationActions,
-    viewModel: SpotifyConnectScreenViewModel = hiltViewModel(),
-    profileViewModel: ProfileViewModel = hiltViewModel()
+    viewModel: SpotifyConnectScreenViewModel = hiltViewModel()
 ) {
   val state by viewModel.uiState.collectAsStateWithLifecycle()
 
   LaunchedEffect(state) {
     if (state.hasResult) {
       if (state.success) {
-        profileViewModel.getProfileOfCurrentUser(false)
-        val profileResult = profileViewModel.uiState.value.error
-        if (profileResult == "Document does not exist") {
-          viewModel.updateState(success = true, isFirstTime = true)
+        viewModel.checkProfile()
+        if (state.isFirstTime) {
+          navigationActions.navigateToTopLevel(Route.EDIT_PROFILE)
         } else {
-          viewModel.updateState(success = true, isFirstTime = false)
+          navigationActions.navigateToTopLevel(Route.MAP)
         }
       } else {
         navigationActions.navigateToTopLevel(Route.LOGIN)
       }
     } else {
       viewModel.connectRemote()
-    }
-  }
-
-  if (state.hasResult && state.success) {
-    if (state.isFirstTime) {
-      navigationActions.navigateToTopLevel(Route.EDIT_PROFILE)
-    } else {
-      navigationActions.navigateToTopLevel(Route.MAP)
     }
   }
 

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifyConnectScreenViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifyConnectScreenViewModel.kt
@@ -36,8 +36,13 @@ constructor(
     _uiState.value = UiState(hasResult = true, success = connectSuccess)
   }
 
+  fun updateState(success: Boolean, isFirstTime: Boolean) {
+    _uiState.value = UiState(hasResult = true, success = success, isFirstTime = isFirstTime)
+  }
+
   data class UiState(
       val hasResult: Boolean = false,
       val success: Boolean = false,
+      val isFirstTime: Boolean = false
   )
 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifyConnectScreenViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/SpotifyConnectScreenViewModel.kt
@@ -2,19 +2,22 @@ package ch.epfl.cs311.wanderwave.viewmodel
 
 import androidx.lifecycle.ViewModel
 import ch.epfl.cs311.wanderwave.model.auth.AuthenticationController
+import ch.epfl.cs311.wanderwave.model.repository.ProfileRepository
 import ch.epfl.cs311.wanderwave.model.spotify.SpotifyController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.runBlocking
 
 @HiltViewModel
 class SpotifyConnectScreenViewModel
 @Inject
 constructor(
     private val spotifyController: SpotifyController,
-    private val authenticationController: AuthenticationController
+    private val authenticationController: AuthenticationController,
+    private val profileRepository: ProfileRepository
 ) : ViewModel() {
 
   private var _uiState = MutableStateFlow(UiState())
@@ -36,8 +39,17 @@ constructor(
     _uiState.value = UiState(hasResult = true, success = connectSuccess)
   }
 
-  fun updateState(success: Boolean, isFirstTime: Boolean) {
-    _uiState.value = UiState(hasResult = true, success = success, isFirstTime = isFirstTime)
+  fun checkProfile() {
+    val userId = authenticationController.getUserData()!!.id
+    runBlocking {
+      val profileResult = profileRepository.getItem(userId).single()
+      if (profileResult.isFailure &&
+          profileResult.exceptionOrNull()?.message == "Document does not exist") {
+        _uiState.value = _uiState.value.copy(isFirstTime = true)
+      } else {
+        _uiState.value = _uiState.value.copy(isFirstTime = false)
+      }
+    }
   }
 
   data class UiState(


### PR DESCRIPTION
I added a `canCancel` option to the `EditProfileScreen` to make cancellation impossible if f it’s the user's first time connecting. In `SpotifyConnectScreen`, I added logic to check if it’s the user's first time connecting by attempting to fetch their profile from the repository. If the profile fetch fails with the error "Document does not exist," the user is redirected to the `EditProfileScreen` instead of the usual flow.
#closes 263
