### PR TITLE
Basic offline mode

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/AppBottomBarTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/AppBottomBarTest.kt
@@ -30,7 +30,7 @@ class AppBottomBarTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompo
 
   @Before
   fun setup() {
-    composeTestRule.setContent { AppBottomBar(mockNavigationActions) }
+    composeTestRule.setContent { AppBottomBar(mockNavigationActions, true) }
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/ProfileTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/ProfileTest.kt
@@ -59,7 +59,7 @@ class ProfileTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
     mockDependencies()
     viewModel = ProfileViewModel(profileRepository, spotifyController, authenticationController)
 
-    composeTestRule.setContent { ProfileScreen(mockNavigationActions, viewModel) }
+    composeTestRule.setContent { ProfileScreen(mockNavigationActions, viewModel, true) }
   }
 
   @After

--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/ui/TrackListScreenTest.kt
@@ -74,7 +74,7 @@ class TrackListScreenTest : TestCase() {
     viewModel = TrackListViewModel(mockSpotifyController, appDatabase, trackRepository)
 
     composeTestRule.setContent {
-      TrackListScreen(mockNavigationActions, mockShowMessage, viewModel)
+      TrackListScreen(mockNavigationActions, mockShowMessage, viewModel, true)
     }
   }
 

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
@@ -168,16 +168,6 @@ constructor(
     appRemote.value = null
   }
 
-  fun getTrackAsListItem(trackId: String): ListItem {
-    // TODO: Implement this
-    return ListItem("", "", ImageUri(""), "", "", false, false)
-  }
-
-  fun isTrackPlayable(trackId: String): Boolean {
-
-    return false
-  }
-
   fun playTrack(track: Track, onSuccess: () -> Unit = {}, onFailure: (Throwable) -> Unit = {}) {
     appRemote.value?.let {
       it.playerApi

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
@@ -167,6 +167,14 @@ constructor(
     appRemote.value.let { SpotifyAppRemote.disconnect(it) }
     appRemote.value = null
   }
+    fun getTrackAsListItem(trackId: String): ListItem {
+        //TODO: Implement this
+        return ListItem("", "", ImageUri(""), "", "", false, false)
+    }
+  fun isTrackPlayable(trackId: String): Boolean {
+
+      return false
+  }
 
   fun playTrack(track: Track, onSuccess: () -> Unit = {}, onFailure: (Throwable) -> Unit = {}) {
     appRemote.value?.let {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/model/spotify/SpotifyController.kt
@@ -167,13 +167,15 @@ constructor(
     appRemote.value.let { SpotifyAppRemote.disconnect(it) }
     appRemote.value = null
   }
-    fun getTrackAsListItem(trackId: String): ListItem {
-        //TODO: Implement this
-        return ListItem("", "", ImageUri(""), "", "", false, false)
-    }
+
+  fun getTrackAsListItem(trackId: String): ListItem {
+    // TODO: Implement this
+    return ListItem("", "", ImageUri(""), "", "", false, false)
+  }
+
   fun isTrackPlayable(trackId: String): Boolean {
 
-      return false
+    return false
   }
 
   fun playTrack(track: Track, onSuccess: () -> Unit = {}, onFailure: (Throwable) -> Unit = {}) {

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/App.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/App.kt
@@ -115,7 +115,8 @@ fun AppScaffold(navController: NavHostController) {
                 composable(Route.TRACK_LIST.routeString) {
                   TrackListScreen(navActions, showSnackbar, trackListViewModel, online)
                 }
-                if (online) composable(Route.MAP.routeString) { MapScreen(navActions, mapViewModel) }
+                if (online)
+                    composable(Route.MAP.routeString) { MapScreen(navActions, mapViewModel) }
                 composable(Route.PROFILE.routeString) {
                   ProfileScreen(navActions, profileViewModel, online)
                 }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/AppBottomBar.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/AppBottomBar.kt
@@ -48,7 +48,7 @@ val mapIcon: ImageVector = Icons.Default.LocationOn
  * @last update 1.0
  */
 @Composable
-fun AppBottomBar(navActions: NavigationActions) {
+fun AppBottomBar(navActions: NavigationActions, online: Boolean) {
   BottomAppBar(
       modifier =
           Modifier.fillMaxWidth()
@@ -75,15 +75,18 @@ fun AppBottomBar(navActions: NavigationActions) {
                   }
             }
 
-        IconButton(
-            onClick = { navActions.navigateToTopLevel(TOP_LEVEL_DESTINATIONS[1].route) },
-            modifier = Modifier.weight(1f).testTag("bottomAppBarButton" + Route.MAP.routeString)) {
-              Image(
-                  modifier = Modifier.padding(top = 5.dp, bottom = 5.dp),
-                  painter = painterResource(id = R.drawable.beaconlogo),
-                  contentDescription = "Beacon icon",
-              )
-            }
+        if (online) {
+          IconButton(
+              onClick = { navActions.navigateToTopLevel(TOP_LEVEL_DESTINATIONS[1].route) },
+              modifier =
+                  Modifier.weight(1f).testTag("bottomAppBarButton" + Route.MAP.routeString)) {
+                Image(
+                    modifier = Modifier.padding(top = 5.dp, bottom = 5.dp),
+                    painter = painterResource(id = R.drawable.beaconlogo),
+                    contentDescription = "Beacon icon",
+                )
+              }
+        }
 
         IconButton(
             onClick = { navActions.navigateToTopLevel(TOP_LEVEL_DESTINATIONS[2].route) },

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/ProfileScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -70,7 +69,7 @@ val INPUT_BOX_NAM_SIZE = 150.dp
  * @last update 2.0
  */
 @Composable
-fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
+fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel, online: Boolean) {
   val currentProfileState by viewModel.profile.collectAsState()
   val songLists by viewModel.songLists.collectAsState()
   val dialogListType by remember { mutableStateOf(ListType.TOP_SONGS) }
@@ -93,10 +92,12 @@ fun ProfileScreen(navActions: NavigationActions, viewModel: ProfileViewModel) {
         Box(modifier = Modifier.fillMaxWidth()) {
           VisitCard(Modifier, currentProfile)
           ProfileSwitch(Modifier.align(Alignment.TopEnd), viewModel)
-          ClickableIcon(
-              Modifier.align(Alignment.BottomEnd),
-              Icons.Filled.Create,
-              onClick = { navActions.navigateTo(Route.EDIT_PROFILE) })
+          if (online) {
+            ClickableIcon(
+                Modifier.align(Alignment.BottomEnd),
+                Icons.Filled.Create,
+                onClick = { navActions.navigateTo(Route.EDIT_PROFILE) })
+          }
         }
         // Toggle Button to switch between TOP SONGS and CHOSEN SONGS
         Button(

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/screens/TrackListScreen.kt
@@ -31,7 +31,8 @@ import ch.epfl.cs311.wanderwave.viewmodel.TrackListViewModel
 fun TrackListScreen(
     navActions: NavigationActions,
     showMessage: (String) -> Unit,
-    viewModel: TrackListViewModel = hiltViewModel()
+    viewModel: TrackListViewModel = hiltViewModel(),
+    online: Boolean
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   var searchQuery by remember { mutableStateOf("") }

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -88,9 +88,7 @@ constructor(
   }
 
   private fun observeTracks() {
-    //Filter only songs already cached/downloaded in Spotify
-
-
+    // Filter only songs already cached/downloaded in Spotify
 
     viewModelScope.launch {
       repository.getAll().collect { tracks ->

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/viewmodel/TrackListViewModel.kt
@@ -88,6 +88,10 @@ constructor(
   }
 
   private fun observeTracks() {
+    //Filter only songs already cached/downloaded in Spotify
+
+
+
     viewModelScope.launch {
       repository.getAll().collect { tracks ->
         _uiState.value =


### PR DESCRIPTION
This creates a basic offline mode where users can browse their tracklist, play songs if they are already downloaded, and view their profiles. 
Unfortunately, despite many many attempts, it seems like there is nothing in the Spotify API that lets us know which songs are available offline, which means that we can't filter them in the tracklist.