### PR TITLE
remove the zoom controls from the map screen

### DIFF
--- a/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/map/WanderwaveGoogleMap.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/ui/components/map/WanderwaveGoogleMap.kt
@@ -33,7 +33,7 @@ fun WanderwaveGoogleMap(
               mapStyleOptions = MapStyleOptions.loadRawResourceStyle(context, R.raw.map_style)),
       uiSettings =
           MapUiSettings(
-              zoomControlsEnabled = controlsEnabled,
+              zoomControlsEnabled = false, // we want this nowhere
               compassEnabled = controlsEnabled,
               myLocationButtonEnabled = controlsEnabled,
               scrollGesturesEnabled = controlsEnabled,


### PR DESCRIPTION
Closes #375 

The "go to my location" button is still there, which I think is fine as this cannot be achieved via gestures, but let me know if I should remove it too.