### PR TITLE
370 bugfix bottom app bar is removed when going back to the beacon

### DIFF
--- a/app/src/androidTest/java/ch/epfl/cs311/wanderwave/utils/NavigationActionsTest.kt
+++ b/app/src/androidTest/java/ch/epfl/cs311/wanderwave/utils/NavigationActionsTest.kt
@@ -1,0 +1,30 @@
+package ch.epfl.cs311.wanderwave.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.epfl.cs311.wanderwave.navigation.Route
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NavigationActionsTest {
+  @Test
+  fun testGetRouteForRouteString() {
+    assertEquals(null, Route.forRouteString("invalid"))
+
+    assertEquals(Route.LOGIN, Route.forRouteString("login"))
+    assertEquals(Route.SPOTIFY_CONNECT, Route.forRouteString("spotifyConnect"))
+    assertEquals(Route.MAIN, Route.forRouteString("main"))
+    assertEquals(Route.TRACK_LIST, Route.forRouteString("trackList"))
+    assertEquals(Route.MAP, Route.forRouteString("map"))
+    assertEquals(Route.PROFILE, Route.forRouteString("profile"))
+    assertEquals(Route.EDIT_PROFILE, Route.forRouteString("editprofile"))
+    assertEquals(Route.VIEW_PROFILE, Route.forRouteString("viewProfile"))
+    assertEquals(Route.ABOUT, Route.forRouteString("about"))
+
+    assertEquals(Route.SELECT_SONG, Route.forRouteString("selectsong"))
+    assertEquals(Route.SELECT_SONG, Route.forRouteString("selectsong/abc"))
+    assertEquals(Route.BEACON, Route.forRouteString("beacon"))
+    assertEquals(Route.BEACON, Route.forRouteString("beacon/abc"))
+  }
+}

--- a/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/epfl/cs311/wanderwave/navigation/NavigationActions.kt
@@ -23,7 +23,8 @@ enum class Route(val routeString: String, val showBottomBar: Boolean) {
 
   companion object {
     fun forRouteString(routeString: String): Route? {
-      return entries.firstOrNull { it.routeString == routeString }
+      val topLevelRouteString = routeString.split("/").firstOrNull()
+      return entries.firstOrNull { it.routeString == topLevelRouteString }
     }
   }
 }
@@ -57,7 +58,6 @@ class NavigationActions(navController: NavHostController) {
       // Restore state when reselecting a previously selected item
       restoreState = true
     }
-    _currentRouteFlow.value = topLevelRoute
   }
 
   fun getCurrentRoute(): Route? {
@@ -69,17 +69,14 @@ class NavigationActions(navController: NavHostController) {
 
   fun navigateTo(route: Route) {
     navigationController.navigate(route.routeString)
-    _currentRouteFlow.value = route
   }
 
   fun navigateToBeacon(beaconId: String) {
     navigationController.navigate("${Route.BEACON.routeString}/$beaconId")
-    _currentRouteFlow.value = Route.BEACON
   }
 
   fun navigateToProfile(profileId: String) {
     navigationController.navigate("${Route.VIEW_PROFILE.routeString}/$profileId")
-    _currentRouteFlow.value = Route.PROFILE
   }
 
   fun navigateToSelectSongScreen(viewModelType: viewModelType) {


### PR DESCRIPTION
Fix the bug that made the bottom bar disappear. Closes #370 

The issue was that the route string that the navigationController gets is something like `beacon/something`, but the function that updates the route flow compares the strings by exact value, so only to `beacon`, which returns `null` for the Route.
Fixed by only comparing the top-level destination string, so everything up to the `/` in the route string.